### PR TITLE
Add `pub fn id()` to Account

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,6 +408,11 @@ impl Account {
         let _ = Problem::from_response(rsp).await?;
         Ok(())
     }
+
+    /// Get the account ID
+    pub fn id(&self) -> &str {
+        &self.inner.id
+    }
 }
 
 struct AccountInner {


### PR DESCRIPTION
This PR adds `pub fn id()` to Account. The account id is used when we need to add the account to [CAA](https://letsencrypt.org/docs/caa/) records.