### PR TITLE
WIP: continued Pebble integration test work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,9 @@ name = "provision"
 required-features = ["hyper-rustls"]
 
 # Pebble integration test.
-# Disabled by default because it requires pebble & pebble-challtestsrv.
+# Ignored by default because it requires pebble & pebble-challtestsrv.
 # Run with:
-#  PEBBLE=path/to/pebble CHALLTESTSRV=path/to/pebble-challtestsrv cargo test --test pebble
+#  PEBBLE=path/to/pebble CHALLTESTSRV=path/to/pebble-challtestsrv cargo test -- --ignored
 [[test]]
 name = "pebble"
 required-features = ["hyper-rustls"]


### PR DESCRIPTION
Following up on our [discussion in #75](https://github.com/djc/instant-acme/pull/75/files#diff-a1a2cd492b88842a03e10323c9cbc714eed91a9cbd0bf74b36ab2554adc9dce1). Here's where I got after an hour or two of fiddling around.

It's a bit messy and I'm holding sync lock guards across await points so clippy isn't pleased. I think the guard type I worked up is pretty poor in general, but it's a place to start.

I also tried to generalize a bit of the order handling logic and got something workable w/ the provisioning callback but I think there's plenty of room for improvement.