### PR TITLE
Implement RFC 8555 §6.7.1 subproblems

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -456,6 +456,14 @@ pub enum Identifier {
     Dns(String),
 }
 
+impl fmt::Display for Identifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Dns(domain) => write!(f, "{domain}"),
+        }
+    }
+}
+
 /// The challenge type
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
When an ACME CA rejects an order submitted by a client it's helpful to be able to indicate _which_ of the order's identifiers are at fault and why. [RFC 8555 §6.7.1](https://www.rfc-editor.org/rfc/rfc8555#section-6.7.1) describes how subproblems within a top-level problem are used for this purpose.

This branch implements support for capturing and rendering problem information containing subproblems based on §6.7.1. Pebble implemented returning subproblems for the case where an identifier in an order is rejected on the basis of CA policy  (https://github.com/letsencrypt/pebble/pull/383). We use this implementation to add a new integration test exercising a problem-with-subproblems response from the test CA.