### PR TITLE
README: small tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ If `fips` is enabled, `aws-lc-rs` is used; otherwise, `ring` is used.
 
 ## Limitations
 
-* Only tested with DNS challenges against Let's Encrypt (staging and production) and ZeroSSL (production) so far
 * Only supports ECDSA keys for now
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ specification.
 * Support for certificate revocation
 * Uses hyper with rustls and Tokio for HTTP requests
 * Uses *ring* or aws-lc-rs for ECDSA signing
-* Minimum supported Rust version: 1.63
+* Minimum supported Rust version (MSRV): 1.70
 
 ## Cargo features
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If `fips` is enabled, `aws-lc-rs` is used; otherwise, `ring` is used.
 
 ## Limitations
 
-* Only supports ECDSA keys for now
+* Only supports P-256 ECDSA account keys for now
 
 ## Getting started
 


### PR DESCRIPTION
* Update MSRV and include the acronym for easier CTRL-F'ing.
* Remove challenge type testing limitation. I'm confident in the other challenge types being RFC 8555 compatible.
* Clarify the key type limitation: firstly that it's specific to account keys (not certificates issued with the account) and secondly that it's only the P-256 ECDSA curve supported.