### PR TITLE
Ignore unmaintained *ring* advisory for now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,3 +9,6 @@ expression = "MIT AND ISC AND OpenSSL"
 license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 }
 ]
+
+[advisories]
+ignore = ["RUSTSEC-2025-0007"]


### PR DESCRIPTION
Let's start here to keep CI passing? And wait for the debris from the advisory to clear...