### PR TITLE
Implement ACME Renewal Information (ARI)

### DIFF
--- a/.github/workflows/pebble.yml
+++ b/.github/workflows/pebble.yml
@@ -23,4 +23,4 @@ jobs:
           curl -L "https://github.com/letsencrypt/pebble/releases/latest/download/pebble-challtestsrv-linux-amd64.tar.gz" | tar xz --strip-components=3
           chmod +x pebble-challtestsrv
       - name: Run integration test
-        run: RUST_LOG=pebble=info cargo test -- --ignored
+        run: RUST_LOG=pebble=info cargo test --features=x509-parser -- --ignored

--- a/.github/workflows/pebble.yml
+++ b/.github/workflows/pebble.yml
@@ -23,4 +23,4 @@ jobs:
           curl -L "https://github.com/letsencrypt/pebble/releases/latest/download/pebble-challtestsrv-linux-amd64.tar.gz" | tar xz --strip-components=3
           chmod +x pebble-challtestsrv
       - name: Run integration test
-        run: RUST_LOG=pebble=info cargo test --features=x509-parser -- --ignored
+        run: RUST_LOG=pebble=info cargo test --features=x509-parser --features=time -- --ignored

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.78"
 thiserror = "2.0.3"
 tokio = { version = "1.22", features = ["time"] }
+x509-parser = { version = "0.17", default-features = false, optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.66"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,8 @@ required-features = ["hyper-rustls"]
 [[test]]
 name = "pebble"
 required-features = ["hyper-rustls"]
+
+[package.metadata.docs.rs]
+# all non-default features except fips (cannot build on docs.rs environment)
+features = ["aws-lc-rs", "x509-parser", "time"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ ring = { version = "0.17", features = ["std"], optional = true }
 rustls-pki-types = "1.1.0"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.78"
+time = { version = "0.3", default-features = false, features = ["serde", "parsing"], optional = true }
 thiserror = "2.0.3"
 tokio = { version = "1.22", features = ["time"] }
 x509-parser = { version = "0.17", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-acme"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.70"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ specification.
 * Support for processing multiple orders concurrently
 * Support for external account binding
 * Support for certificate revocation
+* Support for the [ACME renewal information (ARI)] extension
 * Uses hyper with rustls and Tokio for HTTP requests
 * Uses *ring* or aws-lc-rs for ECDSA signing
 * Minimum supported Rust version (MSRV): 1.70
+
+[ACME renewal information (ARI)]: https://www.ietf.org/archive/id/draft-ietf-acme-ari-08.html
 
 ## Cargo features
 

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -68,7 +68,9 @@ async fn main() -> anyhow::Result<()> {
             .find(|c| c.r#type == ChallengeType::Dns01)
             .ok_or_else(|| anyhow::anyhow!("no dns01 challenge found"))?;
 
-        let Identifier::Dns(identifier) = &authz.identifier;
+        let Identifier::Dns(identifier) = &authz.identifier else {
+            panic!("unsupported identifier type");
+        };
 
         println!("Please set the following DNS record then press the Return key:");
         println!(

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -40,9 +40,7 @@ async fn main() -> anyhow::Result<()> {
 
     let identifier = Identifier::Dns(opts.name.clone());
     let mut order = account
-        .new_order(&NewOrder {
-            identifiers: &[identifier],
-        })
+        .new_order(&NewOrder::new(&[identifier]))
         .await
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![warn(unreachable_pub)]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 use std::error::Error as StdError;
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@ use tokio::time::sleep;
 
 mod types;
 pub use types::{
-    AccountCredentials, Authorization, AuthorizationStatus, Challenge, ChallengeType, Error,
-    Identifier, LetsEncrypt, NewAccount, NewOrder, OrderState, OrderStatus, Problem,
-    RevocationReason, RevocationRequest, ZeroSsl,
+    AccountCredentials, Authorization, AuthorizationStatus, CertificateIdentifier, Challenge,
+    ChallengeType, Error, Identifier, LetsEncrypt, NewAccount, NewOrder, OrderState, OrderStatus,
+    Problem, RevocationReason, RevocationRequest, ZeroSsl,
 };
 use types::{
     DirectoryUrls, Empty, FinalizeRequest, Header, JoseJson, Jwk, KeyOrKeyId, NewAccountPayload,

--- a/src/types.rs
+++ b/src/types.rs
@@ -550,6 +550,7 @@ pub enum AuthorizationStatus {
 /// Represent an identifier in an ACME [Order](crate::Order)
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[non_exhaustive]
 #[serde(tag = "type", content = "value", rename_all = "camelCase")]
 pub enum Identifier {
     Dns(String),

--- a/src/types.rs
+++ b/src/types.rs
@@ -351,7 +351,16 @@ pub struct OrderState {
 #[serde(rename_all = "camelCase")]
 pub struct NewOrder<'a> {
     /// Identifiers to be included in the order
-    pub identifiers: &'a [Identifier],
+    identifiers: &'a [Identifier],
+}
+
+impl<'a> NewOrder<'a> {
+    /// Prepare to create a new order for the given identifiers
+    ///
+    /// To be passed into [Account::new_order()](crate::Account::new_order()).
+    pub fn new(identifiers: &'a [Identifier]) -> Self {
+        Self { identifiers }
+    }
 }
 
 /// Payload for a certificate revocation request

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,6 +15,7 @@ use crate::crypto::{self, KeyPair};
 
 /// Error type for instant-acme
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// An JSON problem as returned by the ACME server
     ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -430,6 +430,10 @@ pub(crate) struct DirectoryUrls {
     pub(crate) new_authz: Option<String>,
     pub(crate) revoke_cert: Option<String>,
     pub(crate) key_change: Option<String>,
+    // Endpoint for the ACME renewal information (ARI) extension
+    //
+    // <https://www.ietf.org/archive/id/draft-ietf-acme-ari-07.html>
+    pub(crate) renewal_info: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,6 +44,9 @@ pub enum Error {
     /// Failed to (de)serialize a JSON object
     #[error("failed to (de)serialize JSON: {0}")]
     Json(#[from] serde_json::Error),
+    /// ACME server does not support a requested feature
+    #[error("ACME server does not support: {0}")]
+    Unsupported(&'static str),
     /// Other kind of error
     #[error(transparent)]
     Other(Box<dyn std::error::Error + Send + Sync + 'static>),

--- a/src/types.rs
+++ b/src/types.rs
@@ -641,6 +641,14 @@ impl CertificateIdentifier<'_> {
             serial: BASE64_URL_SAFE_NO_PAD.encode(serial).into(),
         }
     }
+
+    /// Convert the `CertificateIdentifier` into an owned version with a static lifetime
+    pub fn into_owned(self) -> CertificateIdentifier<'static> {
+        CertificateIdentifier {
+            authority_key_identifier: Cow::Owned(self.authority_key_identifier.into_owned()),
+            serial: Cow::Owned(self.serial.into_owned()),
+        }
+    }
 }
 
 impl<'de: 'a, 'a> Deserialize<'de> for CertificateIdentifier<'a> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -391,6 +391,11 @@ impl<'a> NewOrder<'a> {
         self.replaces = Some(replaces);
         self
     }
+
+    /// Identifiers to be included in the order
+    pub fn identifiers(&self) -> &[Identifier] {
+        self.identifiers
+    }
 }
 
 /// Payload for a certificate revocation request

--- a/src/types.rs
+++ b/src/types.rs
@@ -327,6 +327,7 @@ pub struct Challenge {
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.3>
 #[derive(Debug, Deserialize)]
+#[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct OrderState {
     /// Current status

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -310,12 +310,7 @@ impl Environment {
             .map(|id| Identifier::Dns(id.to_string()))
             .collect::<Vec<_>>();
         debug!(?identifiers, "creating order");
-        let mut order = self
-            .account
-            .new_order(&NewOrder {
-                identifiers: &identifiers,
-            })
-            .await?;
+        let mut order = self.account.new_order(&NewOrder::new(&identifiers)).await?;
         info!(order_url = order.url(), "created order");
 
         let authorizations = order.authorizations().await?;

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -309,10 +309,7 @@ impl Environment {
         &mut self,
         names: &[&'static str],
     ) -> Result<CertificateDer<'static>, Box<dyn StdError + 'static>> {
-        let identifiers = names
-            .iter()
-            .map(|id| Identifier::Dns(id.to_string()))
-            .collect::<Vec<_>>();
+        let identifiers = dns_identifiers(names);
         debug!(?identifiers, "creating order");
         let mut order = self.account.new_order(&NewOrder::new(&identifiers)).await?;
         info!(order_url = order.url(), "created order");
@@ -471,6 +468,13 @@ impl Environment {
             .await?;
         Ok(())
     }
+}
+
+fn dns_identifiers(dns_names: impl IntoIterator<Item = impl ToString>) -> Vec<Identifier> {
+    dns_names
+        .into_iter()
+        .map(|id| Identifier::Dns(id.to_string()))
+        .collect()
 }
 
 struct Http01;

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -1,7 +1,7 @@
 //! Note: tests in the file are ignored by default because they requires `pebble` and
 //! `pebble-challtestsrv` binaries.
 //!
-//! See documentation for [`PebbleEnvironment`].
+//! See documentation for [`Environment`].
 
 use std::collections::HashMap;
 use std::error::Error as StdError;
@@ -182,8 +182,12 @@ fn try_tracing_init() {
 
 /// A test environment running Pebble and a challenge test server
 ///
-/// Subprocesses are torn down cleanly on drop to avoid leaving
-/// stray child processes.
+/// You must have the `pebble` and `pebble-challtestsrv` binaries available
+/// in your `$PATH`, or, set the `PEBBLE` and `CHALLTESTSRV` environment variables
+/// to the paths of the binaries.
+///
+/// Binary downloads for many common platforms are available at:
+/// <https://github.com/letsencrypt/pebble/releases>.
 struct Environment {
     account: Account,
     config: EnvironmentConfig,
@@ -198,6 +202,9 @@ struct Environment {
 
 impl Environment {
     /// Create a new [`Environment`] with running Pebble and challenge test servers
+    ///
+    /// Spawned test server subprocesses are torn down cleanly on drop to avoid leaving
+    /// stray child processes.
     async fn new(config: EnvironmentConfig) -> Result<Environment, Box<dyn StdError>> {
         #[derive(Clone, Serialize)]
         struct ConfigWrapper<'a> {

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -334,7 +334,9 @@ impl Environment {
                 .find(|c| c.r#type == A::TYPE)
                 .ok_or(format!("no {:?} challenge found", A::TYPE))?;
 
-            let Identifier::Dns(identifier) = &authz.identifier;
+            let Identifier::Dns(identifier) = &authz.identifier else {
+                panic!("unsupported identifier type");
+            };
 
             let key_authz = order.key_authorization(challenge);
             self.request_challenge::<A>(identifier, challenge, &key_authz)


### PR DESCRIPTION
This branch implements [ACME Renewal Information](https://www.ietf.org/archive/id/draft-ietf-acme-ari-08.html) based on `draft-08`. While not yet a proposed standard RFC this draft is nearly at that stage, and has been [deployed by Let's Encrypt](https://letsencrypt.org/2023/03/23/improving-resliiency-and-reliability-with-ari/) (and I believe Google as well).

Support brings a few new bits of API surface:

* a new `CertificateIdentifier` type that uniquely identifies a certificate for ARI compatible servers. This requires parsing specific certificate fields to construct, and so without taking a dependency users are expected to provide the relevant `pki_types::Der` data pre-extracted from a certificate.
* for users willing to take an optional `x509-parser` dependency we offer a way to go from `pki_types::CertificateDer<_>` to a `CertificateIdentifier` when the `x509-parser` dependency feature is activated.
* The `DirectoryUrls` type gets a new `renewal_info` field to track the optional ARI endpoint used to signal the ACME server supports ARI.
* When the optional `time` dependency feature is activated, the `Account` struct gains a new `renewal_info()` function that accepts a `CertificateIdentifier` and returns `RenewalInfo` that the caller can use to determine when to replace the identified certificate. This function returns an error if the CA doesn't support ARI.
* The `NewOrder` struct gains a new optional `replaces(cert_id: CertificateIdentifier)` function that can be used to indicate an order is a replacement for a previous order. CAs might use this information to give more generous rate limits, or to know when it's safe to revoke a previously issued certificate due to imposed compliance reasons. Like `Account.renewal_info()` the `Account.new_order()` function will error if provided a `NewOrder` with a `replacement` value if the ACME CA doesn't support ARI.