### PR TITLE
Fix authorization reuse in provision.rs and the Pebble integration tests

### DIFF
--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -193,6 +193,7 @@ impl Environment {
 
         let pebble = Subprocess::new(
             Command::new(&pebble_path)
+                .env("PEBBLE_AUTHZREUSE", config.authz_reuse.to_string())
                 .arg("-config")
                 .arg(config_file.path())
                 .arg("-dnsserver")
@@ -557,6 +558,10 @@ struct EnvironmentConfig {
     dns_port: u16,
     challtestsrv_port: u16,
     eab_key: Option<ExternalAccountKey>,
+    /// Percentage of valid authorizations the Pebble CA will reuse between orders
+    ///
+    /// See <https://github.com/letsencrypt/pebble?tab=readme-ov-file#valid-authorization-reuse>
+    authz_reuse: u8,
 }
 
 impl Default for EnvironmentConfig {
@@ -566,6 +571,7 @@ impl Default for EnvironmentConfig {
             dns_port: NEXT_PORT.fetch_add(1, Ordering::SeqCst),
             challtestsrv_port: NEXT_PORT.fetch_add(1, Ordering::SeqCst),
             eab_key: None,
+            authz_reuse: 50,
         }
     }
 }

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -71,7 +71,7 @@ async fn tls_alpn_01() -> Result<(), Box<dyn StdError>> {
 
     Environment::new(EnvironmentConfig::default())
         .await?
-        .test::<Alpn01>(&["dns01.example.com"])
+        .test::<Alpn01>(&["tlsalpn01.example.com"])
         .await
 }
 


### PR DESCRIPTION
Previously both the provision example and the Pebble integration test logic created a new order for a set of input identifiers, iterated the authorizations for the resulting order, and then pulled out the identifier/challenge for each **pending** status authz. After POSTing each authz's challenge URL the associated challenge identifiers were used for the CSR sent to finalize the order.

Since the logic above only processes pending authz's it would skip any that are already **valid** (e.g. from previous orders). This can end up producing a CSR that has fewer names than the initial order, which provokes an error during finalization when the CA rejects the CSR.

The solution is simple: don't tie the CSR identifiers to the challenges at all, use the same list of identifiers as was used to create the order. Everything else remains the same.

This was manifesting as integration test flakes in https://github.com/djc/instant-acme/pull/85 where we added a test that made multiple orders one after another. Pebble re-uses valid authzs 50% of the time by default, so there was a 50% chance that an incorrect CSR would be submitted, breaking the test.