### PR TITLE
Add authorization and account deactivation

### DIFF
--- a/.github/workflows/pebble.yml
+++ b/.github/workflows/pebble.yml
@@ -14,13 +14,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Download Pebble
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - name: Clone Pebble repo
+        uses: actions/checkout@v4
+        with:
+          repository: letsencrypt/pebble
+          path: pebble-src
+      - name: Build Pebble binaries
+        working-directory: pebble-src
         run: |
-          curl -L "https://github.com/letsencrypt/pebble/releases/latest/download/pebble-linux-amd64.tar.gz" | tar xz --strip-components=3
-          chmod +x pebble
-      - name: Download Pebble Challenge Test Server
-        run: |
-          curl -L "https://github.com/letsencrypt/pebble/releases/latest/download/pebble-challtestsrv-linux-amd64.tar.gz" | tar xz --strip-components=3
-          chmod +x pebble-challtestsrv
+          go build -o $GITHUB_WORKSPACE/pebble ./cmd/pebble
+          go build -o $GITHUB_WORKSPACE/pebble-challtestsrv ./cmd/pebble-challtestsrv
       - name: Run integration test
         run: RUST_LOG=pebble=info cargo test --features=x509-parser --features=time -- --ignored

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -53,7 +53,8 @@ async fn main() -> anyhow::Result<()> {
     let authorizations = order.authorizations().await.unwrap();
     let mut challenges = Vec::with_capacity(authorizations.len());
     for authz in &authorizations {
-        match authz.status {
+        let authz_state = authz.state();
+        match authz_state.status {
             AuthorizationStatus::Pending => {}
             AuthorizationStatus::Valid => continue,
             _ => todo!(),
@@ -62,13 +63,13 @@ async fn main() -> anyhow::Result<()> {
         // We'll use the DNS challenges for this example, but you could
         // pick something else to use here.
 
-        let challenge = authz
+        let challenge = authz_state
             .challenges
             .iter()
             .find(|c| c.r#type == ChallengeType::Dns01)
             .ok_or_else(|| anyhow::anyhow!("no dns01 challenge found"))?;
 
-        let Identifier::Dns(identifier) = &authz.identifier else {
+        let Identifier::Dns(identifier) = &authz_state.identifier else {
             panic!("unsupported identifier type");
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,6 +584,35 @@ impl Account {
         Problem::check::<RenewalInfo>(rsp).await
     }
 
+    /// Deactivate the account with the ACME server
+    ///
+    /// This is useful when you want to cancel an account with the ACME server
+    /// because you don't intend to use it further, or because the account key was
+    /// compromised.
+    ///
+    /// After this point no further operations can be performed with the account.
+    /// Any existing orders or authorizations created with the ACME server will be
+    /// invalidated.
+    pub async fn deactivate(self) -> Result<(), Error> {
+        #[derive(Serialize)]
+        struct DeactivateRequest<'a> {
+            status: &'a str,
+        }
+
+        let _ = self
+            .inner
+            .post(
+                Some(&DeactivateRequest {
+                    status: "deactivated",
+                }),
+                None,
+                self.id(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
     /// Get the account ID
     pub fn id(&self) -> &str {
         &self.inner.id

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ mod types;
 #[cfg(feature = "time")]
 pub use types::RenewalInfo;
 pub use types::{
-    AccountCredentials, Authorization, AuthorizationStatus, CertificateIdentifier, Challenge,
+    AccountCredentials, AuthorizationState, AuthorizationStatus, CertificateIdentifier, Challenge,
     ChallengeType, Error, Identifier, LetsEncrypt, NewAccount, NewOrder, OrderState, OrderStatus,
     Problem, RevocationReason, RevocationRequest, ZeroSsl,
 };
@@ -70,7 +70,7 @@ impl Order {
     /// After the challenges have been set up, check the [`Order::state()`] to see
     /// if the order is ready to be finalized (or becomes invalid). Once it is
     /// ready, call `Order::finalize()` to get the certificate.
-    pub async fn authorizations(&mut self) -> Result<Vec<Authorization>, Error> {
+    pub async fn authorizations(&mut self) -> Result<Vec<AuthorizationState>, Error> {
         let mut authorizations = Vec::with_capacity(self.state.authorizations.len());
         for url in &self.state.authorizations {
             authorizations.push(self.account.get(&mut self.nonce, url).await?);

--- a/src/types.rs
+++ b/src/types.rs
@@ -530,10 +530,10 @@ fn base64(data: &impl Serialize) -> Result<String, serde_json::Error> {
     Ok(BASE64_URL_SAFE_NO_PAD.encode(serde_json::to_vec(data)?))
 }
 
-/// An ACME authorization as described in RFC 8555 (section 7.1.4)
+/// An ACME authorization's state as described in RFC 8555 (section 7.1.4)
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Authorization {
+pub struct AuthorizationState {
     /// The identifier that the account is authorized to represent
     pub identifier: Identifier,
     /// Current state of the authorization
@@ -542,7 +542,7 @@ pub struct Authorization {
     pub challenges: Vec<Challenge>,
 }
 
-/// Status for an [`Authorization`]
+/// Status for an [`AuthorizationState`]
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -875,7 +875,7 @@ mod tests {
           ]
         }"#;
 
-        let obj = serde_json::from_str::<Authorization>(AUTHORIZATION).unwrap();
+        let obj = serde_json::from_str::<AuthorizationState>(AUTHORIZATION).unwrap();
         assert_eq!(obj.status, AuthorizationStatus::Valid);
         assert_eq!(obj.identifier, Identifier::Dns("www.example.org".into()));
         assert_eq!(obj.challenges.len(), 1);

--- a/src/types.rs
+++ b/src/types.rs
@@ -544,7 +544,7 @@ pub struct AuthorizationState {
 
 /// Status for an [`AuthorizationState`]
 #[allow(missing_docs)]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum AuthorizationStatus {
     Pending,
@@ -552,6 +552,7 @@ pub enum AuthorizationStatus {
     Invalid,
     Revoked,
     Expired,
+    Deactivated,
 }
 
 /// Represent an identifier in an ACME [Order](crate::Order)

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -372,19 +372,20 @@ impl Environment {
 
         // Collect up the relevant challenges, provisioning the expected responses as we go.
         for authz in &authorizations {
-            match authz.status {
+            let authz_state = authz.state();
+            match authz_state.status {
                 AuthorizationStatus::Pending => {}
                 AuthorizationStatus::Valid => continue,
-                _ => unreachable!("unexpected authz state: {:?}", authz.status),
+                _ => unreachable!("unexpected authz state: {:?}", authz_state.status),
             }
 
-            let challenge = authz
+            let challenge = authz_state
                 .challenges
                 .iter()
                 .find(|c| c.r#type == A::TYPE)
                 .ok_or(format!("no {:?} challenge found", A::TYPE))?;
 
-            let Identifier::Dns(identifier) = &authz.identifier else {
+            let Identifier::Dns(identifier) = &authz_state.identifier else {
                 panic!("unsupported identifier type");
             };
 


### PR DESCRIPTION
Add support for deactivating authorizations, and ACME accounts. 

Additionally add a wildcard identifier to the DNS-01 integration test and fix the issued certificate validation logic to support this.