### PR TITLE
lib: enforce ARI order state includes replaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -655,11 +655,7 @@ impl Account {
         // "If the Server accepts a new-order request with a "replaces" field, it MUST reflect
         // that field in the response and in subsequent requests for the corresponding Order
         // object."
-        // In practice, Let's Encrypt staging/production are not properly reflecting this field
-        // so we enforce it matches only when the server sends it.
-        // TODO(@cpu): tighten this up once Let's Encrypt is fixed.
-        if order.replaces.is_some() && state.replaces.is_some() && order.replaces != state.replaces
-        {
+        if order.replaces.is_some() && order.replaces != state.replaces {
             return Err(Error::Other(
                 format!(
                     "replaces field mismatch: expected {expected:?}, found {found:?}",


### PR DESCRIPTION
The spec says this is a MUST. We temporarily relaxed this requirement while Let's Encrypt fixed a bug with their server-side ARI implementation. Since that bug was fixed, we can go back to matching what the spec says.

I tested this works as expected with both LE's staging & prod ACME servers. Pebble was already doing the right thing, so no test diff is required.

Follow-up from https://github.com/djc/instant-acme/pull/85