### PR TITLE
Add RFC 8738 IP address identifiers

### DIFF
--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -351,13 +351,13 @@ impl Environment {
         let challtestsrv = Subprocess::new(
             Command::new(&challtestsrv_path)
                 .arg("-management")
-                .arg(format!("[::1]:{}", config.challtestsrv_port))
+                .arg(format!(":{}", config.challtestsrv_port))
                 .arg("-dns01")
-                .arg(format!("[::1]:{}", config.dns_port))
+                .arg(format!(":{}", config.dns_port))
                 .arg("-http01")
-                .arg(format!("[::1]:{}", config.pebble.http_port))
+                .arg(format!(":{}", config.pebble.http_port))
                 .arg("-tlsalpn01")
-                .arg(format!("[::1]:{}", config.pebble.tls_port))
+                .arg(format!(":{}", config.pebble.tls_port))
                 .arg("-https01")
                 .arg("") // Disable HTTP-01 over https:// redirect challenges.
                 .arg("-doh")


### PR DESCRIPTION
While [Let's Encrypt has announced upcoming support](https://letsencrypt.org/2025/01/16/6-day-and-ip-certs/#ip-address-support-for-securing-additional-use-cases) for issuing certificates for IP address subjects, it isn't available yet.

Fortunately, Pebble does support this, so we can implement the feature now and have it ready for Let's Encrypt's staging and production environments.

See [RFC 8738](https://www.rfc-editor.org/rfc/rfc8738).