### PR TITLE
Acme account features

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ specification.
 * Support for certificate revocation
 * Support for the [ACME renewal information (ARI)] extension
 * Support for the [profiles] extension
+* Support for account key rollover
+* Support for account contacts update
 * Uses hyper with rustls and Tokio for HTTP requests
 * Uses *ring* or aws-lc-rs for ECDSA signing
 * Minimum supported Rust version (MSRV): 1.70

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,9 +447,7 @@ impl ChallengeHandle<'_> {
 
         *self.nonce = nonce_from_response(&rsp);
 
-        let response = Problem::check::<Challenge>(rsp).await?;
-
-        Problem::check_challenge(response)?;
+        let _ = Problem::check::<Challenge>(rsp).await?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,9 +447,9 @@ impl ChallengeHandle<'_> {
 
         *self.nonce = nonce_from_response(&rsp);
 
-        let resoponse_payload = Problem::check::<Challenge>(rsp).await?;
+        let response_payload = Problem::check::<Challenge>(rsp).await?;
 
-        if let Some(problem_details) = resoponse_payload.error {
+        if let Some(problem_details) = response_payload.error {
             Err(Error::Api(problem_details))
         } else {
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,10 +449,9 @@ impl ChallengeHandle<'_> {
 
         let response = Problem::check::<Challenge>(rsp).await?;
 
-        match response.error {
-            Some(details) => Err(Error::Api(details)),
-            None => Ok(()),
-        }
+        Problem::check_challenge(response)?;
+
+        Ok(())
     }
 
     /// Create a [`KeyAuthorization`] for this challenge
@@ -794,11 +793,11 @@ impl Account {
 
     /// Account key rollover
     ///
-    /// This is useful if you want to change the acme client key of an existing account, e.g.
-    /// to mitigate the risk of a key compromise. This method crates a new client key and changes
+    /// This is useful if you want to change the ACME account key of an existing account, e.g.
+    /// to mitigate the risk of a key compromise. This method creates a new client key and changes
     /// the key associated with the existing account. In case the key rollover succeeds the new
     /// account credentials are returned for further usage. After that a new Account object with
-    /// the updated client key needs to be crated for further interaction with the acme account.
+    /// the updated client key needs to be crated for further interaction with the ACME account.
     ///
     /// See <https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.5> for more information.
     pub async fn change_key(&self, server_url: &str) -> Result<AccountCredentials, Error> {
@@ -848,7 +847,7 @@ impl Account {
     /// Updates the account contacts
     ///
     /// This is useful if you want to update the contact information of an existing account
-    /// on the acme server. The contacts argument replaces existing contacts on
+    /// on the ACME server. The contacts argument replaces existing contacts on
     /// the server. By providing an empty array the contacts are removed from the server.
     ///
     /// See <https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.2> for more information.
@@ -873,7 +872,7 @@ impl Account {
         let response = Problem::check::<Account>(rsp).await?;
         match response.status {
             AuthorizationStatus::Valid => Ok(()),
-            _ => Err("Unexpected account status after update of account contacts".into()),
+            _ => Err("Unexpected account status after updating contact information".into()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,14 +823,14 @@ impl Account {
             old_key: jwk_old,
         };
 
-        let mut inner_header = new_key.header(Some("nonce"), &new_key_url);
+        let mut inner_header = new_key.header(Some("nonce"), new_key_url);
         inner_header.nonce = None;
 
         let inner_body = JoseJson::new(Some(&payload_inner), inner_header, &new_key)?;
 
         let rsp = self
             .inner
-            .post(Some(&inner_body), None, &new_key_url)
+            .post(Some(&inner_body), None, new_key_url)
             .await?;
 
         let _ = Problem::from_response(rsp).await?;
@@ -873,7 +873,7 @@ impl Account {
         let response = Problem::check::<Account>(rsp).await?;
         match response.status {
             AuthorizationStatus::Valid => Ok(()),
-            _ => Err("Unexpected account status after account key rollover".into()),
+            _ => Err("Unexpected account status after update contacts information".into()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,9 +447,12 @@ impl ChallengeHandle<'_> {
 
         *self.nonce = nonce_from_response(&rsp);
 
-        let _ = Problem::check::<Challenge>(rsp).await?;
+        let response = Problem::check::<Challenge>(rsp).await?;
 
-        Ok(())
+        match response.error {
+            Some(details) => Err(Error::Api(details)),
+            None => Ok(()),
+        }
     }
 
     /// Create a [`KeyAuthorization`] for this challenge

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -873,7 +873,7 @@ impl Account {
         let response = Problem::check::<Account>(rsp).await?;
         match response.status {
             AuthorizationStatus::Valid => Ok(()),
-            _ => Err("Unexpected account status after update contacts information".into()),
+            _ => Err("Unexpected account status after update of account contacts".into()),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -929,6 +929,26 @@ pub(crate) enum SigningAlgorithm {
 #[derive(Debug, Serialize)]
 pub(crate) struct Empty {}
 
+/// Input data for [Account] update of contact
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct AccountContactUpdatePayload<'a> {
+    /// List of contacts
+    pub(crate) contact: &'a [&'a str],
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct NewKeyPayload {
+    pub(crate) account: String,
+    #[serde(rename = "oldKey")]
+    pub(crate) old_key: Jwk,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct AccountPayload {
+    pub(crate) status: String,
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "x509-parser")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -929,26 +929,6 @@ pub(crate) enum SigningAlgorithm {
 #[derive(Debug, Serialize)]
 pub(crate) struct Empty {}
 
-/// Input data for [Account] update of contact
-
-#[derive(Clone, Debug, Serialize)]
-pub(crate) struct AccountContactUpdatePayload<'a> {
-    /// List of contacts
-    pub(crate) contact: &'a [&'a str],
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct NewKeyPayload {
-    pub(crate) account: String,
-    #[serde(rename = "oldKey")]
-    pub(crate) old_key: Jwk,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct AccountPayload {
-    pub(crate) status: String,
-}
-
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "x509-parser")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -171,13 +171,6 @@ impl Problem {
             false => Err(serde_json::from_slice::<Problem>(&body)?.into()),
         }
     }
-
-    pub(crate) fn check_challenge(challenge: Challenge) -> Result<Challenge, Error> {
-        match challenge.error {
-            Some(details) => Err(Error::Api(details)),
-            None => Ok(challenge),
-        }
-    }
 }
 
 impl fmt::Display for Problem {

--- a/src/types.rs
+++ b/src/types.rs
@@ -171,6 +171,13 @@ impl Problem {
             false => Err(serde_json::from_slice::<Problem>(&body)?.into()),
         }
     }
+
+    pub(crate) fn check_challenge(challenge: Challenge) -> Result<Challenge, Error> {
+        match challenge.error {
+            Some(details) => Err(Error::Api(details)),
+            None => Ok(challenge),
+        }
+    }
 }
 
 impl fmt::Display for Problem {

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -307,8 +307,8 @@ async fn account_deactivate() -> Result<(), Box<dyn StdError>> {
     };
 
     assert_eq!(
-        problem.r#type,
-        Some("urn:ietf:params:acme:error:unauthorized".to_string())
+        problem.r#type.as_deref(),
+        Some("urn:ietf:params:acme:error:unauthorized")
     );
     Ok(())
 }
@@ -322,8 +322,7 @@ async fn update_contacts() -> Result<(), Box<dyn StdError>> {
     let env = Environment::new(EnvironmentConfig::default()).await?;
 
     // Provide empty contacts information, this is fine for pebble
-    let result = env.account.update_contacts(&[]).await?;
-    assert_eq!(result, ());
+    env.account.update_contacts(&[]).await?;
 
     // At the time of writing this testcase, pebble does not support contacts information.
     let Err(Error::Api(problem)) = env.account.update_contacts(&["alice@example.com"]).await else {
@@ -331,9 +330,10 @@ async fn update_contacts() -> Result<(), Box<dyn StdError>> {
     };
 
     assert_eq!(
-        problem.r#type,
-        Some("urn:ietf:params:acme:error:unsupportedContact".to_string())
+        problem.r#type.as_deref(),
+        Some("urn:ietf:params:acme:error:unsupportedContact")
     );
+
     Ok(())
 }
 
@@ -343,15 +343,10 @@ async fn change_key() -> Result<(), Box<dyn StdError>> {
     try_tracing_init();
 
     // Creat an env/initial account
-    let mut env = Environment::new(EnvironmentConfig::default()).await?;
+    let env = Environment::new(EnvironmentConfig::default()).await?;
 
     // Change the account key
-    let result = env
-        .account
-        .clone()
-        .change_key("https://[::1]:14000/dir")
-        .await;
-    assert!(result.is_ok());
+    env.account.change_key("https://[::1]:14000/dir").await?;
 
     Ok(())
 }

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -324,15 +324,10 @@ async fn update_contacts() -> Result<(), Box<dyn StdError>> {
     // Provide empty contacts information, this is fine for pebble
     env.account.update_contacts(&[]).await?;
 
-    // At the time of writing this testcase, pebble does not support contacts information.
-    let Err(Error::Api(problem)) = env.account.update_contacts(&["alice@example.com"]).await else {
-        panic!("unexpected result");
-    };
-
-    assert_eq!(
-        problem.r#type.as_deref(),
-        Some("urn:ietf:params:acme:error:unsupportedContact")
-    );
+    // Provide an email address as contacts information
+    env.account
+        .update_contacts(&["mailto:alice@example.com"])
+        .await?;
 
     Ok(())
 }
@@ -351,7 +346,11 @@ async fn change_key() -> Result<(), Box<dyn StdError>> {
     let new_credentials = env.account.change_key(dir).await?;
 
     // Using the old ACME account key should now produce malformed error.
-    let Err(Error::Api(problem)) = env.account.update_contacts(&[]).await else {
+    let Err(Error::Api(problem)) = env
+        .account
+        .update_contacts(&["mailto:bob@example.com"])
+        .await
+    else {
         panic!("unexpected error result");
     };
 
@@ -368,7 +367,9 @@ async fn change_key() -> Result<(), Box<dyn StdError>> {
     .await?;
 
     // Using the new ACME account key should not produce an error.
-    env.account.update_contacts(&[]).await?;
+    env.account
+        .update_contacts(&["mailto:bob@example.com"])
+        .await?;
 
     Ok(())
 }

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -313,6 +313,49 @@ async fn account_deactivate() -> Result<(), Box<dyn StdError>> {
     Ok(())
 }
 
+#[tokio::test]
+#[ignore]
+async fn update_contacts() -> Result<(), Box<dyn StdError>> {
+    try_tracing_init();
+
+    // Creat an env/initial account
+    let env = Environment::new(EnvironmentConfig::default()).await?;
+
+    // Provide empty contacts information, this is fine for pebble
+    let result = env.account.update_contacts(&[]).await?;
+    assert_eq!(result, ());
+
+    // At the time of writing this testcase, pebble does not support contacts information.
+    let Err(Error::Api(problem)) = env.account.update_contacts(&["alice@example.com"]).await else {
+        panic!("unexpected result");
+    };
+
+    assert_eq!(
+        problem.r#type,
+        Some("urn:ietf:params:acme:error:unsupportedContact".to_string())
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn change_key() -> Result<(), Box<dyn StdError>> {
+    try_tracing_init();
+
+    // Creat an env/initial account
+    let mut env = Environment::new(EnvironmentConfig::default()).await?;
+
+    // Change the account key
+    let result = env
+        .account
+        .clone()
+        .change_key("https://[::1]:14000/dir")
+        .await;
+    assert!(result.is_ok());
+
+    Ok(())
+}
+
 fn try_tracing_init() {
     let _ = tracing_subscriber::registry()
         .with(fmt::layer())


### PR DESCRIPTION
This pull request adds account features and one fix to the instant-acme client:

- A new feature is added to update the contact information of an existing acme account
- A new feature is added to perform an account key rollover of an existing acme account

The contact information that is part of the acme account is according to RFC 8555, section 7.3.2. The contact update payload includes a the contact information as for example an email address.

The account key rollover is according to RFC 8555, section 7.3.5. New credentials are created by the instant-acme client and updated on the acme server. The new credentials are returned to the caller for further usage.
