### PR TITLE
probem details from challenge object

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,8 +446,13 @@ impl ChallengeHandle<'_> {
             .await?;
 
         *self.nonce = nonce_from_response(&rsp);
-        let _ = Problem::check::<Challenge>(rsp).await?;
-        Ok(())
+
+        let response = Problem::check::<Challenge>(rsp).await?;
+
+        match response.error {
+            Some(details) => Err(Error::Api(details)),
+            None => Ok(()),
+        }
     }
 
     /// Create a [`KeyAuthorization`] for this challenge


### PR DESCRIPTION
This pull requests improves api error reporting for challenge set_ready.

If an ACME server provides error information on the HTTP layer as a RFC 8707 probem details document, this error information is provided to the caller of the set_ready method as Error::Api(...). But if an ACME server provides the error information as part of the Challenge object (error member, RFC8555 section 8) the current implementation does not forward this information to the caller of set_ready as an Err(Error::Api(...)). This is changed in this pull request.
