### PR TITLE
ci: switch back to pre-built Pebble

### DIFF
--- a/.github/workflows/pebble.yml
+++ b/.github/workflows/pebble.yml
@@ -14,18 +14,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
-      - name: Clone Pebble repo
-        uses: actions/checkout@v4
-        with:
-          repository: letsencrypt/pebble
-          path: pebble-src
-      - name: Build Pebble binaries
-        working-directory: pebble-src
+      - name: Download Pebble
         run: |
-          go build -o $GITHUB_WORKSPACE/pebble ./cmd/pebble
-          go build -o $GITHUB_WORKSPACE/pebble-challtestsrv ./cmd/pebble-challtestsrv
+          curl -L "https://github.com/letsencrypt/pebble/releases/latest/download/pebble-linux-amd64.tar.gz" | tar xz --strip-components=3
+          chmod +x pebble
+      - name: Download Pebble Challenge Test Server
+        run: |
+          curl -L "https://github.com/letsencrypt/pebble/releases/latest/download/pebble-challtestsrv-linux-amd64.tar.gz" | tar xz --strip-components=3
+          chmod +x pebble-challtestsrv
       - name: Run integration test
         run: RUST_LOG=pebble=info cargo test --features=x509-parser --features=time -- --ignored


### PR DESCRIPTION
Previously our CI needed [a fix that was merged to Pebble main](https://github.com/letsencrypt/pebble/commit/dc9bf9d200b49f5b587258ec53948f17417a7579), but not yet released, so we switched to building it from source.

There's since been a [v2.8.0](https://github.com/letsencrypt/pebble/releases/tag/v2.8.0) release that includes the required fix so we can switch back to using pre-built release binaries.