### PR TITLE
Encapsulate retry policy in a type

### DIFF
--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -7,7 +7,7 @@ use tracing::info;
 
 use instant_acme::{
     Account, AuthorizationStatus, ChallengeType, Identifier, LetsEncrypt, NewAccount, NewOrder,
-    OrderStatus,
+    OrderStatus, RetryPolicy,
 };
 
 #[tokio::main]
@@ -81,7 +81,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Exponentially back off until the order becomes ready or invalid.
 
-    let status = order.poll(5, Duration::from_millis(250)).await?;
+    let status = order.poll(&RetryPolicy::default()).await?;
     if status != OrderStatus::Ready {
         return Err(anyhow::anyhow!("unexpected order status: {status:?}"));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use account::{Account, ExternalAccountKey};
 mod order;
 pub use order::{
     AuthorizationHandle, Authorizations, ChallengeHandle, Identifiers, KeyAuthorization, Order,
+    RetryPolicy,
 };
 mod types;
 #[cfg(feature = "time")]


### PR DESCRIPTION
This type can be constructed and updated in a const context and is mostly opaque so we can evolve what the exact policy looks like without API changes.