### PR TITLE
Use builder pattern for Account creation

### DIFF
--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -19,16 +19,17 @@ async fn main() -> anyhow::Result<()> {
     // Alternatively, restore an account from serialized credentials by
     // using `Account::from_credentials()`.
 
-    let (account, credentials) = Account::create(
-        &NewAccount {
-            contact: &[],
-            terms_of_service_agreed: true,
-            only_return_existing: false,
-        },
-        LetsEncrypt::Staging.url().to_owned(),
-        None,
-    )
-    .await?;
+    let (account, credentials) = Account::builder()?
+        .create(
+            &NewAccount {
+                contact: &[],
+                terms_of_service_agreed: true,
+                only_return_existing: false,
+            },
+            LetsEncrypt::Staging.url().to_owned(),
+            None,
+        )
+        .await?;
     info!(
         "account credentials:\n\n{}",
         serde_json::to_string_pretty(&credentials)?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use serde::Serialize;
 
 mod account;
 use account::Key;
-pub use account::{Account, ExternalAccountKey};
+pub use account::{Account, AccountBuilder, ExternalAccountKey};
 mod order;
 pub use order::{
     AuthorizationHandle, Authorizations, ChallengeHandle, Identifiers, KeyAuthorization, Order,
@@ -329,14 +329,18 @@ mod tests {
     #[tokio::test]
     async fn deserialize_old_credentials() -> Result<(), Error> {
         const CREDENTIALS: &str = r#"{"id":"id","key_pkcs8":"MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgJVWC_QzOTCS5vtsJp2IG-UDc8cdDfeoKtxSZxaznM-mhRANCAAQenCPoGgPFTdPJ7VLLKt56RxPlYT1wNXnHc54PEyBg3LxKaH0-sJkX0mL8LyPEdsfL_Oz4TxHkWLJGrXVtNhfH","urls":{"newNonce":"new-nonce","newAccount":"new-acct","newOrder":"new-order", "revokeCert": "revoke-cert"}}"#;
-        Account::from_credentials(serde_json::from_str::<AccountCredentials>(CREDENTIALS)?).await?;
+        Account::builder()?
+            .from_credentials(serde_json::from_str::<AccountCredentials>(CREDENTIALS)?)
+            .await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn deserialize_new_credentials() -> Result<(), Error> {
         const CREDENTIALS: &str = r#"{"id":"id","key_pkcs8":"MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgJVWC_QzOTCS5vtsJp2IG-UDc8cdDfeoKtxSZxaznM-mhRANCAAQenCPoGgPFTdPJ7VLLKt56RxPlYT1wNXnHc54PEyBg3LxKaH0-sJkX0mL8LyPEdsfL_Oz4TxHkWLJGrXVtNhfH","directory":"https://acme-staging-v02.api.letsencrypt.org/directory"}"#;
-        Account::from_credentials(serde_json::from_str::<AccountCredentials>(CREDENTIALS)?).await?;
+        Account::builder()?
+            .from_credentials(serde_json::from_str::<AccountCredentials>(CREDENTIALS)?)
+            .await?;
         Ok(())
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -517,7 +517,7 @@ pub(crate) struct NewAccountPayload<'a> {
 
 /// Input data for [Account](crate::Account) creation
 ///
-/// To be passed into [Account::create()](crate::Account::create()).
+/// To be passed into [AccountBuilder::create()](crate::AccountBuilder::create()).
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NewAccount<'a> {

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -358,11 +358,9 @@ async fn update_key() -> Result<(), Box<dyn StdError>> {
     );
 
     // Change the Pebble environment to use the new ACME account key.
-    env.account = instant_acme::Account::from_credentials_and_http(
-        new_credentials,
-        Box::new(env.client.clone()),
-    )
-    .await?;
+    env.account = instant_acme::Account::builder_with_http(Box::new(env.client.clone()))
+        .from_credentials(new_credentials)
+        .await?;
 
     // Using the new ACME account key should not produce an error.
     env.account
@@ -476,17 +474,17 @@ impl Environment {
 
         // Create a new `Account` with the ACME server.
         debug!("creating test account");
-        let (account, _) = Account::create_with_http(
-            &NewAccount {
-                contact: &[],
-                terms_of_service_agreed: true,
-                only_return_existing: false,
-            },
-            format!("https://{}/dir", &config.pebble.listen_address),
-            config.eab_key.as_ref(),
-            Box::new(client.clone()),
-        )
-        .await?;
+        let (account, _) = Account::builder_with_http(Box::new(client.clone()))
+            .create(
+                &NewAccount {
+                    contact: &[],
+                    terms_of_service_agreed: true,
+                    only_return_existing: false,
+                },
+                format!("https://{}/dir", &config.pebble.listen_address),
+                config.eab_key.as_ref(),
+            )
+            .await?;
         info!(account_id = account.id(), "created ACME account");
 
         Ok(Self {


### PR DESCRIPTION
To avoid combinatorial explosion of constructors.

Preparation for #94.