### PR TITLE
poll certificate function

### DIFF
--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -82,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Exponentially back off until the order becomes ready or invalid.
 
-    let status = order.poll(&RetryPolicy::default()).await?;
+    let status = order.poll_ready(&RetryPolicy::default()).await?;
     if status != OrderStatus::Ready {
         return Err(anyhow::anyhow!("unexpected order status: {status:?}"));
     }

--- a/src/order.rs
+++ b/src/order.rs
@@ -166,7 +166,7 @@ impl Order {
     ///
     /// Yields the [`OrderStatus`] immediately if `Ready` or `Invalid`, or yields an
     /// [`Error::Timeout`] if the [`RetryPolicy::timeout`] has been reached.
-    pub async fn poll(&mut self, retries: &RetryPolicy) -> Result<OrderStatus, Error> {
+    pub async fn poll_ready(&mut self, retries: &RetryPolicy) -> Result<OrderStatus, Error> {
         let mut retrying = retries.state();
         self.retry_after = None;
         loop {
@@ -428,8 +428,8 @@ impl Deref for AuthorizationHandle<'_> {
 /// * Set up the challenge response in your infrastructure (details vary by challenge type)
 /// * Call [`ChallengeHandle::set_ready()`] for that challenge after setup is complete
 ///
-/// After the challenges have been set to ready, call [`Order::poll()`] to wait until the order is
-/// ready to be finalized (or to learn if it becomes invalid). Once it is ready, call
+/// After the challenges have been set to ready, call [`Order::poll_ready()`] to wait until the
+/// order is ready to be finalized (or to learn if it becomes invalid). Once it is ready, call
 /// [`Order::finalize()`] to get the certificate.
 ///
 /// Dereferences to the underlying [`Challenge`] for easy access to the challenge's state.

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -597,7 +597,7 @@ impl Environment {
         }
 
         // Poll until the order is ready.
-        let status = order.poll(&RETRY_POLICY).await?;
+        let status = order.poll_ready(&RETRY_POLICY).await?;
         if status != OrderStatus::Ready {
             return Err(format!("unexpected order status: {status:?}").into());
         }

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -653,12 +653,7 @@ impl Environment {
         debug!(order_url = order.url(), "finalizing order");
         order.finalize().await?;
         debug!(order_url = order.url(), "fetching order certificate chain");
-        let cert_chain_pem = loop {
-            match order.certificate().await.unwrap() {
-                Some(cert_chain_pem) => break cert_chain_pem,
-                None => sleep(Duration::from_secs(1)).await,
-            }
-        };
+        let cert_chain_pem = order.poll_certificate(&RETRY_POLICY).await.unwrap();
 
         // Parse the PEM chain into a vec of DER certificates ordered ee -> intermediates.
         info!("successfully issued certificate");


### PR DESCRIPTION
This pull request adds a new function to poll a certificate. In contrast to the existing `Order::certificate` function, this method retries in case of a `Processing` state based on the retry policy. 

Pebble testing is modified such that it uses the new method `Order::poll_certificate`. This removes a `loop` from the test function `Environment::certificate`.

I can add commits to this pr if wanted:
- rename `Order::poll` to `Order::poll_ready`
- remove public from `Order::certificate`