### PR TITLE
extend renewal_info() to yield retry-after header

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "hyper-rustls")]
 use crate::DefaultClient;
-use crate::order::{Order, retry_after};
+use crate::order::Order;
 use crate::types::{
     AccountCredentials, AuthorizationStatus, Empty, Header, JoseJson, Jwk, KeyOrKeyId, NewAccount,
     NewAccountPayload, NewOrder, OrderState, Problem, ProfileMeta, RevocationRequest, Signer,
@@ -22,7 +22,7 @@ use crate::types::{
 };
 #[cfg(feature = "time")]
 use crate::types::{CertificateIdentifier, RenewalInfo};
-use crate::{BytesResponse, Client, Error, HttpClient, crypto, nonce_from_response};
+use crate::{BytesResponse, Client, Error, HttpClient, crypto, nonce_from_response, retry_after};
 
 /// An ACME account as described in RFC 8555 (section 7.1.2)
 ///

--- a/src/order.rs
+++ b/src/order.rs
@@ -622,7 +622,7 @@ impl RetryState {
 ///
 /// Retry-After = HTTP-date / delay-seconds
 /// delay-seconds  = 1*DIGIT
-fn retry_after(rsp: &BytesResponse) -> Option<SystemTime> {
+pub(crate) fn retry_after(rsp: &BytesResponse) -> Option<SystemTime> {
     let value = rsp.parts.headers.get(RETRY_AFTER)?.to_str().ok()?.trim();
     if value.is_empty() {
         return None;

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -229,7 +229,10 @@ async fn replacement_order() -> Result<(), Box<dyn StdError>> {
         .expect("failed to fetch renewal window");
 
     // Since we revoked the initial certificate, the window start should be in the past.
-    assert!(renewal_info.suggested_window.start < OffsetDateTime::now_utc());
+    assert!(renewal_info.0.suggested_window.start < OffsetDateTime::now_utc());
+
+    // The next iteration to update the window should be in the future.
+    assert!(renewal_info.1 > Duration::ZERO);
 
     // So, let's go ahead and issue a replacement certificate.
     env.test::<Http01>(&NewOrder::new(&dns_identifiers(names)).replaces(initial_cert_id))


### PR DESCRIPTION
This pull request adds an extension to the function `Account::renewal_info()` to additionally yield the Retry-After header as a `SystemTime`. Reference is [RFC 9773, 4.3.2 Client Handling of Retry-After](https://www.rfc-editor.org/rfc/rfc9773.html#section-4.3.2). The `SystemTime` is a hint from the ACME server when to again fetch the renewal window.
