### PR TITLE
ci: add external types and semver compat checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,18 @@ jobs:
       - run: cargo doc --locked --all-features --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: -Dwarnings
-          
+
+  semver:
+    name: Check semver compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   check-external-types:
     name: Validate external types appearing in public API
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,6 +77,23 @@ jobs:
       - run: cargo doc --locked --all-features --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: -Dwarnings
+          
+  check-external-types:
+    name: Validate external types appearing in public API
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-05-04
+          # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
+      - run: cargo install --locked cargo-check-external-types
+      - name: run cargo-check-external-types
+        run: cargo check-external-types --all-features
 
   audit:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,18 @@ required-features = ["hyper-rustls"]
 # all non-default features except fips (cannot build on docs.rs environment)
 features = ["aws-lc-rs", "x509-parser", "time"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    "aws_lc_rs::*",
+    "base64::*",
+    "bytes::*",
+    "http::*",
+    "http_body::*",
+    "http_body_util::*",
+    "hyper::*",
+    "hyper_util::*",
+    "rustls_pki_types::*",
+    "serde::*",
+    "serde_json::*",
+]


### PR DESCRIPTION
The external types situation isn't great ATM (mostly due to the `HttpClient` trait, and the `Error` enum) but we can at least prevent backsliding with a CI check while considering improvements to reduce the number of blessed deps.