### PR TITLE
Prepare 0.8 release

### DIFF
--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -1,8 +1,6 @@
 use std::io;
-use std::time::Duration;
 
 use clap::Parser;
-use tokio::time::sleep;
 use tracing::info;
 
 use instant_acme::{
@@ -90,12 +88,7 @@ async fn main() -> anyhow::Result<()> {
     // Finalize the order and print certificate chain, private key and account credentials.
 
     let private_key_pem = order.finalize().await?;
-    let cert_chain_pem = loop {
-        match order.certificate().await? {
-            Some(cert_chain_pem) => break cert_chain_pem,
-            None => sleep(Duration::from_secs(1)).await,
-        }
-    };
+    let cert_chain_pem = order.poll_certificate(&RetryPolicy::default()).await?;
 
     info!("certificate chain:\n\n{cert_chain_pem}");
     info!("private key:\n\n{private_key_pem}");

--- a/src/types.rs
+++ b/src/types.rs
@@ -710,6 +710,7 @@ impl fmt::Display for AuthorizedIdentifier<'_> {
 
 /// The challenge type
 #[allow(missing_docs)]
+#[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub enum ChallengeType {
     #[serde(rename = "http-01")]


### PR DESCRIPTION
## Proposed release notes

The 0.8 release contains substantial changes to make the API more modular. It integrates full support for ACME Renewal Information (ARI, recently standardized as RFC 9773).

* Add support for the ACME profiles extension draft (see #98).
* Add support for the ACME renewal information extension (see #85).
* Add support for IP address identifiers (#97).
* Use a builder setup to build accounts via `Account::builder()` or `Account::builder_with_http()` (see #110).
* `NewOrder` values must be created through a builder as well (via `NewOrder::new()`).
* Authorizations can now be accessed via a stream-like API available through `Order::authorizations()` (see #92).
* Integrated API to poll order readiness and certificate, with configurable retry policy (see #108, #121).

When upgrading, consider reviewing the [diff](https://github.com/djc/instant-acme/compare/0.7.2...main?expand=1#diff-37a59a73e0d463036965c9b5e473e761d7a5f11c527554c388398b37f2aa2a28) for our example code.
