### PR TITLE
Fail CI on yanked dependencies

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,6 @@
+[advisories]
+yanked = "deny"
+
 [licenses]
 version = 2
 allow = ["Apache-2.0", "BSD-3-Clause", "CDLA-Permissive-2.0", "ISC", "MIT", "OpenSSL", "Unicode-3.0"]


### PR DESCRIPTION
IMO this is a good default, and I've been using instant-acme as my Rust template repository of choice...