### PR TITLE
reworked challenge/handle representation, dns-persist-01 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ specification.
 * Supported extensions:
   * [ACME renewal information (ARI)]
   * [Profiles]
+  * [draft-ietf-acme-device-attest] (**Experimental**)
 * Support for external account binding, key rollover, and contact updates
 * Support for certificate revocation
 * Store/recover your account credentials by serializing/deserializing
@@ -28,6 +29,7 @@ specification.
 
 [ACME renewal information (ARI)]: https://www.rfc-editor.org/rfc/rfc9773.html
 [profiles]: https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/
+[draft-ietf-acme-device-attest]: https://datatracker.ietf.org/doc/draft-ietf-acme-device-attest/
 
 ## Cargo features
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ specification.
   * [ACME renewal information (ARI)]
   * [Profiles]
   * [draft-ietf-acme-device-attest] (**Experimental**)
+  * [draft-ietf-acme-dns-persist] (**Experimental**)
 * Support for external account binding, key rollover, and contact updates
 * Support for certificate revocation
 * Store/recover your account credentials by serializing/deserializing
@@ -30,6 +31,7 @@ specification.
 [ACME renewal information (ARI)]: https://www.rfc-editor.org/rfc/rfc9773.html
 [profiles]: https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/
 [draft-ietf-acme-device-attest]: https://datatracker.ietf.org/doc/draft-ietf-acme-device-attest/
+[draft-ietf-acme-dns-persist]: https://datatracker.ietf.org/doc/draft-ietf-acme-dns-persist/
 
 ## Cargo features
 
@@ -47,6 +49,7 @@ If both `ring` and `aws-lc-rs` are enabled, `aws-lc-rs` will be used.
 
 * Only supports P-256 ECDSA account keys for now
 * Device attestation support is experimental
+* dns-persist-01 support is experimental
 
 ## Getting started
 

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -71,7 +71,7 @@ async fn main() -> anyhow::Result<()> {
         println!(
             "_acme-challenge.{} IN TXT {}",
             challenge.identifier(),
-            challenge.key_authorization().dns_value()
+            challenge.key_authorization().unwrap().dns_value()
         );
         io::stdin().read_line(&mut String::new())?;
 

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -68,10 +68,11 @@ async fn main() -> anyhow::Result<()> {
             .ok_or_else(|| anyhow::anyhow!("no dns01 challenge found"))?;
 
         println!("Please set the following DNS record then press the Return key:");
+        let authz_response = challenge.authorization();
         println!(
-            "_acme-challenge.{} IN TXT {}",
-            challenge.identifier(),
-            challenge.key_authorization().dns_value()
+            "{} IN TXT {}",
+            authz_response.host(),
+            authz_response.rdata()
         );
         io::stdin().read_line(&mut String::new())?;
 

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -4,8 +4,8 @@ use clap::Parser;
 use tracing::info;
 
 use instant_acme::{
-    Account, AuthorizationStatus, ChallengeType, Identifier, LetsEncrypt, NewAccount, NewOrder,
-    OrderStatus, RetryPolicy,
+    Account, AuthorizationStatus, Identifier, LetsEncrypt, NewAccount, NewOrder, OrderStatus,
+    RetryPolicy,
 };
 
 #[tokio::main]
@@ -64,14 +64,14 @@ async fn main() -> anyhow::Result<()> {
         // pick something else to use here.
 
         let mut challenge = authz
-            .challenge(ChallengeType::Dns01)
+            .dns01()
             .ok_or_else(|| anyhow::anyhow!("no dns01 challenge found"))?;
 
         println!("Please set the following DNS record then press the Return key:");
         println!(
             "_acme-challenge.{} IN TXT {}",
             challenge.identifier(),
-            challenge.key_authorization().unwrap().dns_value()
+            challenge.key_authorization().dns_value()
         );
         io::stdin().read_line(&mut String::new())?;
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -346,7 +346,7 @@ impl Account {
 pub(crate) struct AccountInner {
     client: Arc<Client>,
     pub(crate) key: Key,
-    id: String,
+    pub(crate) id: String,
 }
 
 impl AccountInner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,8 @@ pub use account::Key;
 pub use account::{Account, AccountBuilder, ExternalAccountKey};
 mod order;
 pub use order::{
-    AuthorizationHandle, Authorizations, ChallengeHandle, Identifiers, Order, RetryPolicy,
+    AuthorizationHandle, Authorizations, DeviceAttest01ChallengeHandle, Dns01ChallengeHandle,
+    Http01ChallengeHandle, Identifiers, Order, RetryPolicy, TlsAlpn01ChallengeHandle,
 };
 mod types;
 pub use types::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,10 +43,10 @@ pub use order::{
 mod types;
 pub use types::{
     AccountCredentials, Authorization, AuthorizationState, AuthorizationStatus,
-    AuthorizedIdentifier, CertificateIdentifier, Challenge, ChallengeStatus, ChallengeType,
-    DeviceAttestation, Error, Identifier, KeyAuthorization, LetsEncrypt, NewAccount, NewOrder,
-    OrderState, OrderStatus, Problem, ProfileMeta, RevocationReason, RevocationRequest, Subproblem,
-    ZeroSsl,
+    AuthorizedIdentifier, CertificateIdentifier, Challenge, ChallengeState, ChallengeStatus,
+    ChallengeType, DeviceAttestation, Dns01Challenge, Error, Http01Challenge, Identifier,
+    KeyAuthorization, LetsEncrypt, NewAccount, NewOrder, OrderState, OrderStatus, Problem,
+    ProfileMeta, RevocationReason, RevocationRequest, Subproblem, TlsAlpn01Challenge, ZeroSsl,
 };
 use types::{Directory, JoseJson, Signer};
 #[cfg(feature = "time")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,10 @@ mod types;
 pub use types::{
     AccountCredentials, Authorization, AuthorizationState, AuthorizationStatus,
     AuthorizedIdentifier, CertificateIdentifier, Challenge, ChallengeState, ChallengeStatus,
-    ChallengeType, DeviceAttestation, Dns01Challenge, Error, Http01Challenge, Identifier,
-    KeyAuthorization, LetsEncrypt, NewAccount, NewOrder, OrderState, OrderStatus, Problem,
-    ProfileMeta, RevocationReason, RevocationRequest, Subproblem, TlsAlpn01Challenge, ZeroSsl,
+    ChallengeType, DeviceAttestation, Dns01Challenge, Dns01ChallengeAuthorization, Error,
+    Http01Challenge, Http01ChallengeAuthorization, Identifier, LetsEncrypt, NewAccount, NewOrder,
+    OrderState, OrderStatus, Problem, ProfileMeta, RevocationReason, RevocationRequest, Subproblem,
+    TlsAlpn01Challenge, TlsAlpn01ChallengeAuthorization, ZeroSsl,
 };
 use types::{Directory, JoseJson, Signer};
 #[cfg(feature = "time")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,16 +39,18 @@ pub use account::{Account, AccountBuilder, ExternalAccountKey};
 mod order;
 pub use order::{
     AuthorizationHandle, Authorizations, DeviceAttest01ChallengeHandle, Dns01ChallengeHandle,
-    Http01ChallengeHandle, Identifiers, Order, RetryPolicy, TlsAlpn01ChallengeHandle,
+    DnsPersist01ChallengeHandle, DnsPersist01RecordBuilder, Http01ChallengeHandle, Identifiers,
+    Order, RetryPolicy, TlsAlpn01ChallengeHandle,
 };
 mod types;
 pub use types::{
     AccountCredentials, Authorization, AuthorizationState, AuthorizationStatus,
     AuthorizedIdentifier, CertificateIdentifier, Challenge, ChallengeState, ChallengeStatus,
-    ChallengeType, DeviceAttestation, Dns01Challenge, Dns01ChallengeAuthorization, Error,
-    Http01Challenge, Http01ChallengeAuthorization, Identifier, LetsEncrypt, NewAccount, NewOrder,
-    OrderState, OrderStatus, Problem, ProfileMeta, RevocationReason, RevocationRequest, Subproblem,
-    TlsAlpn01Challenge, TlsAlpn01ChallengeAuthorization, ZeroSsl,
+    ChallengeType, DeviceAttestation, Dns01Challenge, Dns01ChallengeAuthorization,
+    DnsPersist01Challenge, DnsPersist01ChallengeAuthorization, Error, Http01Challenge,
+    Http01ChallengeAuthorization, Identifier, IssuerDomainName, IssuerDomainNames, LetsEncrypt,
+    NewAccount, NewOrder, OrderState, OrderStatus, Problem, ProfileMeta, RevocationReason,
+    RevocationRequest, Subproblem, TlsAlpn01Challenge, TlsAlpn01ChallengeAuthorization, ZeroSsl,
 };
 use types::{Directory, JoseJson, Signer};
 #[cfg(feature = "time")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,15 +38,15 @@ pub use account::Key;
 pub use account::{Account, AccountBuilder, ExternalAccountKey};
 mod order;
 pub use order::{
-    AuthorizationHandle, Authorizations, ChallengeHandle, Identifiers, KeyAuthorization, Order,
-    RetryPolicy,
+    AuthorizationHandle, Authorizations, ChallengeHandle, Identifiers, Order, RetryPolicy,
 };
 mod types;
 pub use types::{
     AccountCredentials, Authorization, AuthorizationState, AuthorizationStatus,
     AuthorizedIdentifier, CertificateIdentifier, Challenge, ChallengeStatus, ChallengeType,
-    DeviceAttestation, Error, Identifier, LetsEncrypt, NewAccount, NewOrder, OrderState,
-    OrderStatus, Problem, ProfileMeta, RevocationReason, RevocationRequest, Subproblem, ZeroSsl,
+    DeviceAttestation, Error, Identifier, KeyAuthorization, LetsEncrypt, NewAccount, NewOrder,
+    OrderState, OrderStatus, Problem, ProfileMeta, RevocationReason, RevocationRequest, Subproblem,
+    ZeroSsl,
 };
 use types::{Directory, JoseJson, Signer};
 #[cfg(feature = "time")]

--- a/src/order.rs
+++ b/src/order.rs
@@ -504,7 +504,7 @@ impl ChallengeHandle<'_> {
     /// the challenge's `KeyAuthorization`. The `KeyAuthorization` must be used to provision the
     /// expected challenge response based on the challenge type in use.
     pub fn key_authorization(&self) -> KeyAuthorization {
-        KeyAuthorization::new(self.challenge, &self.account.key)
+        KeyAuthorization::new(&self.challenge.token, &self.account.key)
     }
 
     /// The identifier for this challenge's authorization
@@ -529,8 +529,8 @@ impl Deref for ChallengeHandle<'_> {
 pub struct KeyAuthorization(String);
 
 impl KeyAuthorization {
-    fn new(challenge: &Challenge, key: &Key) -> Self {
-        Self(format!("{}.{}", challenge.token, &key.thumb))
+    fn new(token: &str, key: &Key) -> Self {
+        Self(format!("{token}.{}", &key.thumb))
     }
 
     /// Get the key authorization value

--- a/src/order.rs
+++ b/src/order.rs
@@ -13,13 +13,13 @@ use tokio::time::sleep;
 use crate::account::AccountInner;
 use crate::types::{
     Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Challenge,
-    ChallengeStatus, ChallengeType, DeviceAttestation, Empty, Error, FinalizeRequest, OrderState,
-    OrderStatus, Problem,
+    ChallengeStatus, ChallengeType, DeviceAttestation, DnsPersist01ChallengeAuthorization, Empty,
+    Error, FinalizeRequest, OrderState, OrderStatus, Problem,
 };
 use crate::{
-    ChallengeState, Dns01Challenge, Dns01ChallengeAuthorization, Http01Challenge,
-    Http01ChallengeAuthorization, Identifier, TlsAlpn01Challenge, TlsAlpn01ChallengeAuthorization,
-    nonce_from_response, retry_after,
+    ChallengeState, Dns01Challenge, Dns01ChallengeAuthorization, DnsPersist01Challenge,
+    Http01Challenge, Http01ChallengeAuthorization, Identifier, IssuerDomainName, IssuerDomainNames,
+    TlsAlpn01Challenge, TlsAlpn01ChallengeAuthorization, nonce_from_response, retry_after,
 };
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
@@ -457,6 +457,35 @@ impl<'a> AuthorizationHandle<'a> {
         })
     }
 
+    /// Get a handle for the dns-persist-01 challenge, if present
+    ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifer is not
+    /// a [`Identifier::Dns`] type identifier.
+    ///
+    /// Note: DNS persist challenge support is experimental.
+    pub fn dns_persist01(&'a mut self) -> Option<DnsPersist01ChallengeHandle<'a>> {
+        // Notably dns-persist-01 does not support IP address identifiers.
+        if !matches!(self.state.identifier().identifier, Identifier::Dns(_)) {
+            return None;
+        }
+
+        let challenge = challenge_for_type(&self.state.challenges, ChallengeType::DnsPersist01)?;
+
+        let ChallengeState::DnsPersist01(data) = &challenge.state else {
+            return None;
+        };
+
+        Some(DnsPersist01ChallengeHandle {
+            state: ChallengeHandleState {
+                identifier: self.state.identifier(),
+                challenge,
+                nonce: self.nonce,
+                account: self.account,
+            },
+            challenge: data,
+        })
+    }
+
     /// Get a handle for the TLS-ALPN-01 challenge, if present
     ///
     /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
@@ -600,6 +629,166 @@ impl Deref for Dns01ChallengeHandle<'_> {
 
     fn deref(&self) -> &Self::Target {
         self.state.challenge
+    }
+}
+
+/// Handle for DNS-PERSIST-01 challenges
+///
+/// Note: DNS persist challenge support is experimental.
+pub struct DnsPersist01ChallengeHandle<'a> {
+    state: ChallengeHandleState<'a>,
+    challenge: &'a DnsPersist01Challenge,
+}
+
+impl DnsPersist01ChallengeHandle<'_> {
+    /// Notify the server that the challenge is ready to be completed
+    pub async fn set_ready(&mut self) -> Result<(), Error> {
+        self.state.set_ready().await
+    }
+
+    /// The issuer domain names accepted by the CA
+    pub fn issuer_domain_names(&self) -> &IssuerDomainNames {
+        &self.challenge.issuer_domain_names
+    }
+
+    /// The identifier for this challenge's authorization
+    pub fn identifier(&self) -> &AuthorizedIdentifier<'_> {
+        &self.state.identifier
+    }
+
+    /// Create a builder for the DNS TXT record response
+    ///
+    /// The `issuer` must be one of the issuer domain names returned by
+    /// [`issuer_domain_names()`][Self::issuer_domain_names()]. Returns an error
+    /// if the provided issuer is not in the challenge's list of accepted issuers.
+    ///
+    /// The account URI is automatically populated from the account used to create
+    /// the order.
+    ///
+    /// If the challenge authorizes a wildcard DNS identifier, the challenge response
+    /// wildcard policy will be automatically set to true.
+    pub fn response_txt_record<'a>(
+        &'a self,
+        issuer: &'a IssuerDomainName,
+    ) -> Result<DnsPersist01RecordBuilder<'a>, Error> {
+        DnsPersist01RecordBuilder::new(
+            &self.state.account.id,
+            issuer,
+            self.challenge,
+            self.state.identifier.clone(),
+        )
+    }
+}
+
+impl Deref for DnsPersist01ChallengeHandle<'_> {
+    type Target = Challenge;
+
+    fn deref(&self) -> &Self::Target {
+        self.state.challenge
+    }
+}
+
+/// Builder for creating a DNS-PERSIST-01 TXT record
+///
+/// Created via [`DnsPersist01ChallengeHandle::response_txt_record()`].
+#[derive(Debug)]
+pub struct DnsPersist01RecordBuilder<'a> {
+    account_uri: &'a str,
+    issuer: &'a IssuerDomainName,
+    identifier: AuthorizedIdentifier<'a>,
+    persist_until: Option<u64>,
+    wildcard: bool,
+}
+
+impl<'a> DnsPersist01RecordBuilder<'a> {
+    /// Create a new builder for a DNS-PERSIST-01 record
+    ///
+    /// Validates that:
+    /// - The issuer is in the challenge's list of accepted issuer domain names
+    /// - The identifier is a DNS identifier
+    ///
+    /// The `wildcard` field is automatically set based on the identifier's wildcard flag.
+    pub(crate) fn new(
+        account_uri: &'a str,
+        issuer: &'a IssuerDomainName,
+        challenge: &'a DnsPersist01Challenge,
+        identifier: AuthorizedIdentifier<'a>,
+    ) -> Result<Self, Error> {
+        if !matches!(identifier.identifier, Identifier::Dns(_)) {
+            return Err(Error::Str(
+                "dns-persist-01 challenge requires a DNS identifier",
+            ));
+        }
+
+        if !account_uri.is_ascii() {
+            return Err(Error::Str("account URI must be ASCII"));
+        }
+
+        if !challenge.issuer_domain_names.as_ref().contains(issuer) {
+            return Err(Error::InvalidIssuerDomains(format!(
+                "issuer '{}' is not in the challenge's issuer domain names",
+                issuer.as_ref()
+            )));
+        }
+
+        Ok(Self {
+            account_uri,
+            issuer,
+            persist_until: None,
+            wildcard: identifier.wildcard,
+            identifier,
+        })
+    }
+
+    /// Set the `persistUntil` parameter
+    ///
+    /// The value must be a base-10 encoded integer representing a UNIX timestamp
+    /// (the number of seconds since 1970-01-01T00:00:00Z ignoring leap seconds).
+    ///
+    /// CAs will not consider the validation record valid for new validation
+    /// attempts after the specified timestamp.
+    ///
+    /// See <https://datatracker.ietf.org/doc/html/draft-ietf-acme-dns-persist-00#section-7.9>
+    /// for important considerations for domain owners using this parameter.
+    pub fn persist_until(mut self, timestamp: u64) -> Self {
+        self.persist_until = Some(timestamp);
+        self
+    }
+
+    /// Enable the `policy=wildcard` parameter
+    ///
+    /// Builders created from a [`DnsPersist01ChallengeHandle`] corresponding to a
+    /// wildcard identifier will automatically enable this policy.
+    ///
+    /// For other non-wildcard identifiers, opting in to this policy by calling
+    /// `wildcard()` will allow you to issue for wildcard identifiers using the
+    /// same ACME account in the future.
+    ///
+    /// When set, the validation will be sufficient for issuing certificates for:
+    /// - The validated FQDN itself
+    /// - Wildcard certificates (e.g., `*.example.com`)
+    /// - Specific subdomains of the validated FQDN
+    pub fn wildcard(mut self) -> Self {
+        self.wildcard = true;
+        self
+    }
+
+    /// Build the final [`DnsPersist01ChallengeAuthorization`]
+    ///
+    /// Use the returned record to update your authoritative DNS with the challenge
+    /// response record contents.
+    pub fn build(self) -> DnsPersist01ChallengeAuthorization {
+        let mut rdata = format!("{}; accounturi={}", self.issuer.as_ref(), self.account_uri);
+
+        if self.wildcard {
+            rdata.push_str("; policy=wildcard");
+        }
+
+        if let Some(timestamp) = self.persist_until {
+            rdata.push_str(&format!("; persistUntil={}", timestamp));
+        }
+
+        DnsPersist01ChallengeAuthorization::new(self.identifier.identifier, &rdata)
     }
 }
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -395,7 +395,11 @@ impl<'a> AuthorizationHandle<'a> {
     ///
     /// Yields an object to interact with the challenge for the given type, if available.
     pub fn challenge(&'a mut self, r#type: ChallengeType) -> Option<ChallengeHandle<'a>> {
-        let challenge = self.state.challenges.iter().find(|c| c.r#type == r#type)?;
+        let challenge = self
+            .state
+            .challenges
+            .iter()
+            .find(|c| c.state.r#type() == r#type)?;
         Some(ChallengeHandle {
             identifier: self.state.identifier(),
             challenge,
@@ -472,7 +476,7 @@ impl ChallengeHandle<'_> {
         &mut self,
         payload: &DeviceAttestation<'_>,
     ) -> Result<ChallengeStatus, Error> {
-        if self.challenge.r#type != ChallengeType::DeviceAttest01 {
+        if self.challenge.state.r#type() != ChallengeType::DeviceAttest01 {
             return Err(Error::Str("challenge type should be device-attest-01"));
         }
 
@@ -499,13 +503,20 @@ impl ChallengeHandle<'_> {
         }
     }
 
-    /// Create a [`KeyAuthorization`] for this challenge
+    /// Create a [`KeyAuthorization`] for this challenge if applicable
     ///
     /// Combines a challenge's token with the thumbprint of the account's public key to compute
     /// the challenge's `KeyAuthorization`. The `KeyAuthorization` must be used to provision the
     /// expected challenge response based on the challenge type in use.
-    pub fn key_authorization(&self) -> KeyAuthorization {
-        KeyAuthorization::new(&self.challenge.token, &self.account.key)
+    ///
+    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a `KeyAuthorization`. Other challenge
+    /// types do not rely on this mechanism and will return `None`, expecting the challenge to be
+    /// satisfied with another method specific to its type.
+    pub fn key_authorization(&self) -> Option<KeyAuthorization> {
+        self.challenge
+            .state
+            .token()
+            .map(|t| KeyAuthorization::new(t, &self.account.key))
     }
 
     /// The identifier for this challenge's authorization

--- a/src/order.rs
+++ b/src/order.rs
@@ -18,7 +18,7 @@ use crate::types::{
 };
 use crate::{
     ChallengeState, Dns01Challenge, Dns01ChallengeAuthorization, Http01Challenge,
-    Http01ChallengeAuthorization, TlsAlpn01Challenge, TlsAlpn01ChallengeAuthorization,
+    Http01ChallengeAuthorization, Identifier, TlsAlpn01Challenge, TlsAlpn01ChallengeAuthorization,
     nonce_from_response, retry_after,
 };
 
@@ -280,7 +280,7 @@ pub struct Identifiers<'a> {
 }
 
 impl<'a> Identifiers<'a> {
-    /// Yield the next [`Identifier`][crate::Identifier], fetching the authorization's state if
+    /// Yield the next [`Identifier`], fetching the authorization's state if
     /// we don't have it yet
     pub async fn next(&mut self) -> Option<Result<AuthorizedIdentifier<'a>, Error>> {
         Some(match self.inner.next().await? {
@@ -402,7 +402,17 @@ impl<'a> AuthorizationHandle<'a> {
     }
 
     /// Get a handle for the HTTP-01 challenge, if present
+    ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::Dns`] or [`Identifier::Ip`] type identifier.
     pub fn http01(&'a mut self) -> Option<Http01ChallengeHandle<'a>> {
+        if !matches!(
+            self.state.identifier().identifier,
+            Identifier::Dns(_) | Identifier::Ip(_)
+        ) {
+            return None;
+        }
+
         let challenge = challenge_for_type(&self.state.challenges, ChallengeType::Http01)?;
 
         let ChallengeState::Http01(data) = &challenge.state else {
@@ -421,7 +431,15 @@ impl<'a> AuthorizationHandle<'a> {
     }
 
     /// Get a handle for the DNS-01 challenge, if present
+    ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::Dns`] type identifier.
     pub fn dns01(&'a mut self) -> Option<Dns01ChallengeHandle<'a>> {
+        // Notably DNS-01 does not support IP address identifiers.
+        if !matches!(self.state.identifier().identifier, Identifier::Dns(_)) {
+            return None;
+        }
+
         let challenge = challenge_for_type(&self.state.challenges, ChallengeType::Dns01)?;
 
         let ChallengeState::Dns01(data) = &challenge.state else {
@@ -440,7 +458,17 @@ impl<'a> AuthorizationHandle<'a> {
     }
 
     /// Get a handle for the TLS-ALPN-01 challenge, if present
+    ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::Dns`] or [`Identifier::Ip`] type identifier.
     pub fn tls_alpn01(&'a mut self) -> Option<TlsAlpn01ChallengeHandle<'a>> {
+        if !matches!(
+            self.state.identifier().identifier,
+            Identifier::Dns(_) | Identifier::Ip(_)
+        ) {
+            return None;
+        }
+
         let challenge = challenge_for_type(&self.state.challenges, ChallengeType::TlsAlpn01)?;
 
         let ChallengeState::TlsAlpn01(data) = &challenge.state else {
@@ -460,8 +488,18 @@ impl<'a> AuthorizationHandle<'a> {
 
     /// Get a handle for the device-attest-01 challenge, if present
     ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::PermanentIdentifier`] or [`Identifier::HardwareModule`] type identifier.
+    ///
     /// Note: Device attestation support is experimental.
     pub fn device_attest01(&'a mut self) -> Option<DeviceAttest01ChallengeHandle<'a>> {
+        if !matches!(
+            self.state.identifier().identifier,
+            Identifier::PermanentIdentifier(_) | Identifier::HardwareModule(_)
+        ) {
+            return None;
+        }
+
         Some(DeviceAttest01ChallengeHandle {
             state: ChallengeHandleState {
                 identifier: self.state.identifier(),

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 use std::ops::{ControlFlow, Deref};
+use std::slice;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
-use std::{fmt, slice};
 
 use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine};
 #[cfg(feature = "rcgen")]
@@ -13,9 +13,10 @@ use tokio::time::sleep;
 use crate::account::AccountInner;
 use crate::types::{
     Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Challenge,
-    ChallengeType, DeviceAttestation, Empty, FinalizeRequest, OrderState, OrderStatus, Problem,
+    ChallengeType, DeviceAttestation, Empty, FinalizeRequest, KeyAuthorization, OrderState,
+    OrderStatus, Problem,
 };
-use crate::{ChallengeStatus, Error, Key, crypto, nonce_from_response, retry_after};
+use crate::{ChallengeStatus, Error, nonce_from_response, retry_after};
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
 ///
@@ -518,48 +519,6 @@ impl Deref for ChallengeHandle<'_> {
 
     fn deref(&self) -> &Self::Target {
         self.challenge
-    }
-}
-
-/// The response value to use for challenge responses
-///
-/// Refer to the methods below to see which encoding to use for your challenge type.
-///
-/// <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>
-pub struct KeyAuthorization(String);
-
-impl KeyAuthorization {
-    fn new(token: &str, key: &Key) -> Self {
-        Self(format!("{token}.{}", &key.thumb))
-    }
-
-    /// Get the key authorization value
-    ///
-    /// This can be used for HTTP-01 challenge responses.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    /// Get the SHA-256 digest of the key authorization
-    ///
-    /// This can be used for TLS-ALPN-01 challenge responses.
-    ///
-    /// <https://datatracker.ietf.org/doc/html/rfc8737#section-3>
-    pub fn digest(&self) -> impl AsRef<[u8]> {
-        crypto::digest(&crypto::SHA256, self.0.as_bytes())
-    }
-
-    /// Get the base64-encoded SHA256 digest of the key authorization
-    ///
-    /// This can be used for DNS-01 challenge responses.
-    pub fn dns_value(&self) -> String {
-        BASE64_URL_SAFE_NO_PAD.encode(self.digest())
-    }
-}
-
-impl fmt::Debug for KeyAuthorization {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("KeyAuthorization").finish()
     }
 }
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -16,7 +16,10 @@ use crate::types::{
     ChallengeStatus, ChallengeType, DeviceAttestation, Empty, Error, FinalizeRequest,
     KeyAuthorization, OrderState, OrderStatus, Problem,
 };
-use crate::{nonce_from_response, retry_after};
+use crate::{
+    ChallengeState, Dns01Challenge, Http01Challenge, TlsAlpn01Challenge, nonce_from_response,
+    retry_after,
+};
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
 ///
@@ -321,8 +324,14 @@ impl<'a> AuthStream<'a> {
 /// For each authorization, you'll need to:
 ///
 /// * Select which [`ChallengeType`] you want to complete
-/// * Call [`AuthorizationHandle::challenge()`] to get a [`ChallengeHandle`]
-/// * Use the `ChallengeHandle` to complete the authorization's challenge
+/// * Call the appropriate challenge handle accessor to get a type specific challenge
+///   handle (e.g. [`AuthorizationHandle::http01()`], [`AuthorizationHandle::dns01()`],
+///   etc).
+/// * Use the handle to complete the authorization's challenge (e.g. provisioning an
+///   HTTP-01 response with [`Http01ChallengeHandle::authorization()`]).
+/// * Use the handle to indicate to the ACME CA that you're ready for validation to occur
+///   (e.g. for HTTP-01 with [`Http01ChallengeHandle::set_ready()`], or for device-attest-01
+///   with [`DeviceAttest01ChallengeHandle::send_attestation()`]).
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.3>
 pub struct AuthorizationHandle<'a> {
@@ -391,20 +400,77 @@ impl<'a> AuthorizationHandle<'a> {
         }
     }
 
-    /// Get a [`ChallengeHandle`] for the given `type`
+    /// Get a handle for the HTTP-01 challenge, if present
+    pub fn http01(&'a mut self) -> Option<Http01ChallengeHandle<'a>> {
+        let challenge = challenge_for_type(&self.state.challenges, ChallengeType::Http01)?;
+
+        let ChallengeState::Http01(data) = &challenge.state else {
+            return None;
+        };
+
+        Some(Http01ChallengeHandle {
+            state: ChallengeHandleState {
+                identifier: self.state.identifier(),
+                challenge,
+                nonce: self.nonce,
+                account: self.account,
+            },
+            challenge: data,
+        })
+    }
+
+    /// Get a handle for the DNS-01 challenge, if present
+    pub fn dns01(&'a mut self) -> Option<Dns01ChallengeHandle<'a>> {
+        let challenge = challenge_for_type(&self.state.challenges, ChallengeType::Dns01)?;
+
+        let ChallengeState::Dns01(data) = &challenge.state else {
+            return None;
+        };
+
+        Some(Dns01ChallengeHandle {
+            state: ChallengeHandleState {
+                identifier: self.state.identifier(),
+                challenge,
+                nonce: self.nonce,
+                account: self.account,
+            },
+            challenge: data,
+        })
+    }
+
+    /// Get a handle for the TLS-ALPN-01 challenge, if present
+    pub fn tls_alpn01(&'a mut self) -> Option<TlsAlpn01ChallengeHandle<'a>> {
+        let challenge = challenge_for_type(&self.state.challenges, ChallengeType::TlsAlpn01)?;
+
+        let ChallengeState::TlsAlpn01(data) = &challenge.state else {
+            return None;
+        };
+
+        Some(TlsAlpn01ChallengeHandle {
+            state: ChallengeHandleState {
+                identifier: self.state.identifier(),
+                challenge,
+                nonce: self.nonce,
+                account: self.account,
+            },
+            challenge: data,
+        })
+    }
+
+    /// Get a handle for the device-attest-01 challenge, if present
     ///
-    /// Yields an object to interact with the challenge for the given type, if available.
-    pub fn challenge(&'a mut self, r#type: ChallengeType) -> Option<ChallengeHandle<'a>> {
-        let challenge = self
-            .state
-            .challenges
-            .iter()
-            .find(|c| c.state.r#type() == r#type)?;
-        Some(ChallengeHandle {
-            identifier: self.state.identifier(),
-            challenge,
-            nonce: self.nonce,
-            account: self.account,
+    /// Note: Device attestation support is experimental.
+    pub fn device_attest01(&'a mut self) -> Option<DeviceAttest01ChallengeHandle<'a>> {
+        Some(DeviceAttest01ChallengeHandle {
+            state: ChallengeHandleState {
+                identifier: self.state.identifier(),
+                challenge: challenge_for_type(
+                    &self.state.challenges,
+                    ChallengeType::DeviceAttest01,
+                )?,
+                nonce: self.nonce,
+                account: self.account,
+            },
         })
     }
 
@@ -422,64 +488,132 @@ impl Deref for AuthorizationHandle<'_> {
     }
 }
 
-/// Wrapper type for interacting with a [`Challenge`]'s state
-///
-/// For each challenge, you'll need to:
-///
-/// * Obtain the [`ChallengeHandle::key_authorization()`] for the challenge response
-/// * Set up the challenge response in your infrastructure (details vary by challenge type)
-/// * Call [`ChallengeHandle::set_ready()`] for that challenge after setup is complete
-///
-/// After the challenges have been set to ready, call [`Order::poll_ready()`] to wait until the
-/// order is ready to be finalized (or to learn if it becomes invalid). Once it is ready, call
-/// [`Order::finalize()`] to get the certificate.
-///
-/// Dereferences to the underlying [`Challenge`] for easy access to the challenge's state.
-pub struct ChallengeHandle<'a> {
-    identifier: AuthorizedIdentifier<'a>,
-    challenge: &'a Challenge,
-    nonce: &'a mut Option<String>,
-    account: &'a AccountInner,
+/// Handle for RFC 8555 HTTP-01 challenges
+pub struct Http01ChallengeHandle<'a> {
+    state: ChallengeHandleState<'a>,
+    challenge: &'a Http01Challenge,
 }
 
-impl ChallengeHandle<'_> {
-    /// Notify the server that the given challenge is ready to be completed
+impl Http01ChallengeHandle<'_> {
+    /// Notify the server that the challenge is ready to be completed
     pub async fn set_ready(&mut self) -> Result<(), Error> {
-        let rsp = self
-            .account
-            .post(Some(&Empty {}), self.nonce.take(), &self.challenge.url)
-            .await?;
-
-        *self.nonce = nonce_from_response(&rsp);
-        let response = Problem::check::<Challenge>(rsp).await?;
-        match response.error {
-            Some(details) => Err(Error::Api(details)),
-            None => Ok(()),
-        }
+        self.state.set_ready().await
     }
 
+    /// The identifier for this challenge's authorization
+    pub fn identifier(&self) -> &AuthorizedIdentifier<'_> {
+        &self.state.identifier
+    }
+
+    /// The token for this challenge
+    pub fn token(&self) -> &str {
+        &self.challenge.token
+    }
+
+    /// Create a [`KeyAuthorization`] for this challenge
+    pub fn key_authorization(&self) -> KeyAuthorization {
+        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    }
+}
+
+impl Deref for Http01ChallengeHandle<'_> {
+    type Target = Challenge;
+
+    fn deref(&self) -> &Self::Target {
+        self.state.challenge
+    }
+}
+
+/// Handle for RFC 8555 DNS-01 challenges
+pub struct Dns01ChallengeHandle<'a> {
+    state: ChallengeHandleState<'a>,
+    challenge: &'a Dns01Challenge,
+}
+
+impl Dns01ChallengeHandle<'_> {
+    /// Notify the server that the challenge is ready to be completed
+    pub async fn set_ready(&mut self) -> Result<(), Error> {
+        self.state.set_ready().await
+    }
+
+    /// The identifier for this challenge's authorization
+    pub fn identifier(&self) -> &AuthorizedIdentifier<'_> {
+        &self.state.identifier
+    }
+
+    /// The token for this challenge
+    pub fn token(&self) -> &str {
+        &self.challenge.token
+    }
+
+    /// Create a [`KeyAuthorization`] for this challenge
+    pub fn key_authorization(&self) -> KeyAuthorization {
+        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    }
+}
+
+impl Deref for Dns01ChallengeHandle<'_> {
+    type Target = Challenge;
+
+    fn deref(&self) -> &Self::Target {
+        self.state.challenge
+    }
+}
+
+/// Handle for RFC 8737 TLS-ALPN-01 challenges
+pub struct TlsAlpn01ChallengeHandle<'a> {
+    state: ChallengeHandleState<'a>,
+    challenge: &'a TlsAlpn01Challenge,
+}
+
+impl TlsAlpn01ChallengeHandle<'_> {
+    /// Notify the server that the challenge is ready to be completed
+    pub async fn set_ready(&mut self) -> Result<(), Error> {
+        self.state.set_ready().await
+    }
+
+    /// The identifier for this challenge's authorization
+    pub fn identifier(&self) -> &AuthorizedIdentifier<'_> {
+        &self.state.identifier
+    }
+
+    /// The token for this challenge
+    pub fn token(&self) -> &str {
+        &self.challenge.token
+    }
+
+    /// Create a [`KeyAuthorization`] for this challenge
+    pub fn key_authorization(&self) -> KeyAuthorization {
+        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    }
+}
+
+impl Deref for TlsAlpn01ChallengeHandle<'_> {
+    type Target = Challenge;
+
+    fn deref(&self) -> &Self::Target {
+        self.state.challenge
+    }
+}
+
+/// Handle for draft-ietf-acme-device-attest device-attest-01 challenges
+///
+/// Note: device attestation support is experimental.
+pub struct DeviceAttest01ChallengeHandle<'a> {
+    state: ChallengeHandleState<'a>,
+}
+
+impl DeviceAttest01ChallengeHandle<'_> {
     /// Notify the server that the challenge is ready by sending a device attestation
     ///
-    /// This function is for the ACME challenge device-attest-01. It should not be used
-    /// with other challenge types.
-    /// See <https://datatracker.ietf.org/doc/draft-acme-device-attest/> for details.
+    /// See <https://datatracker.ietf.org/doc/draft-ietf-acme-device-attest/> for details.
     ///
-    /// `payload` is the device attestation object as defined in link. Provide the attestation
-    /// object as a raw blob. Base64 encoding of the attestation object `payload.att_obj`
-    /// is done by this function.
-    ///
-    /// The function yields the challenge status from the ACME server that validated the
-    /// attestation challenge.
-    ///
-    /// Note: Device attestation support is experimental.
-    pub async fn send_device_attestation(
+    /// `payload` is the device attestation object. Provide the attestation
+    /// object as a raw blob; base64 encoding is done by this function.
+    pub async fn send_attestation(
         &mut self,
         payload: &DeviceAttestation<'_>,
     ) -> Result<ChallengeStatus, Error> {
-        if self.challenge.state.r#type() != ChallengeType::DeviceAttest01 {
-            return Err(Error::Str("challenge type should be device-attest-01"));
-        }
-
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
         struct DeviceAttestationBase64<'a> {
@@ -491,11 +625,16 @@ impl ChallengeHandle<'_> {
         };
 
         let rsp = self
+            .state
             .account
-            .post(Some(&payload), self.nonce.take(), &self.challenge.url)
+            .post(
+                Some(&payload),
+                self.state.nonce.take(),
+                &self.state.challenge.url,
+            )
             .await?;
 
-        *self.nonce = nonce_from_response(&rsp);
+        *self.state.nonce = nonce_from_response(&rsp);
         let response = Problem::check::<Challenge>(rsp).await?;
         match response.error {
             Some(details) => Err(Error::Api(details)),
@@ -503,33 +642,17 @@ impl ChallengeHandle<'_> {
         }
     }
 
-    /// Create a [`KeyAuthorization`] for this challenge if applicable
-    ///
-    /// Combines a challenge's token with the thumbprint of the account's public key to compute
-    /// the challenge's `KeyAuthorization`. The `KeyAuthorization` must be used to provision the
-    /// expected challenge response based on the challenge type in use.
-    ///
-    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a `KeyAuthorization`. Other challenge
-    /// types do not rely on this mechanism and will return `None`, expecting the challenge to be
-    /// satisfied with another method specific to its type.
-    pub fn key_authorization(&self) -> Option<KeyAuthorization> {
-        self.challenge
-            .state
-            .token()
-            .map(|t| KeyAuthorization::new(t, &self.account.key))
-    }
-
     /// The identifier for this challenge's authorization
     pub fn identifier(&self) -> &AuthorizedIdentifier<'_> {
-        &self.identifier
+        &self.state.identifier
     }
 }
 
-impl Deref for ChallengeHandle<'_> {
+impl Deref for DeviceAttest01ChallengeHandle<'_> {
     type Target = Challenge;
 
     fn deref(&self) -> &Self::Target {
-        self.challenge
+        self.state.challenge
     }
 }
 
@@ -624,4 +747,33 @@ impl RetryState {
             false => ControlFlow::Continue(()),
         }
     }
+}
+
+/// Shared state common to all challenges
+struct ChallengeHandleState<'a> {
+    identifier: AuthorizedIdentifier<'a>,
+    challenge: &'a Challenge,
+    nonce: &'a mut Option<String>,
+    account: &'a AccountInner,
+}
+
+impl ChallengeHandleState<'_> {
+    /// Notify the server that the given challenge is ready to be completed
+    async fn set_ready(&mut self) -> Result<(), Error> {
+        let rsp = self
+            .account
+            .post(Some(&Empty {}), self.nonce.take(), &self.challenge.url)
+            .await?;
+
+        *self.nonce = nonce_from_response(&rsp);
+        let response = Problem::check::<Challenge>(rsp).await?;
+        match response.error {
+            Some(details) => Err(Error::Api(details)),
+            None => Ok(()),
+        }
+    }
+}
+
+fn challenge_for_type(challenges: &[Challenge], r#type: ChallengeType) -> Option<&Challenge> {
+    challenges.iter().find(|c| c.state.r#type() == r#type)
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -13,12 +13,13 @@ use tokio::time::sleep;
 use crate::account::AccountInner;
 use crate::types::{
     Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Challenge,
-    ChallengeStatus, ChallengeType, DeviceAttestation, Empty, Error, FinalizeRequest,
-    KeyAuthorization, OrderState, OrderStatus, Problem,
+    ChallengeStatus, ChallengeType, DeviceAttestation, Empty, Error, FinalizeRequest, OrderState,
+    OrderStatus, Problem,
 };
 use crate::{
-    ChallengeState, Dns01Challenge, Http01Challenge, TlsAlpn01Challenge, nonce_from_response,
-    retry_after,
+    ChallengeState, Dns01Challenge, Dns01ChallengeAuthorization, Http01Challenge,
+    Http01ChallengeAuthorization, TlsAlpn01Challenge, TlsAlpn01ChallengeAuthorization,
+    nonce_from_response, retry_after,
 };
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
@@ -510,9 +511,9 @@ impl Http01ChallengeHandle<'_> {
         &self.challenge.token
     }
 
-    /// Create a [`KeyAuthorization`] for this challenge
-    pub fn key_authorization(&self) -> KeyAuthorization {
-        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    /// Create a [`Http01ChallengeAuthorization`] for this challenge
+    pub fn authorization(&self) -> Http01ChallengeAuthorization {
+        Http01ChallengeAuthorization::new(&self.challenge.token, &self.state.account.key)
     }
 }
 
@@ -546,9 +547,13 @@ impl Dns01ChallengeHandle<'_> {
         &self.challenge.token
     }
 
-    /// Create a [`KeyAuthorization`] for this challenge
-    pub fn key_authorization(&self) -> KeyAuthorization {
-        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    /// Create a [`Dns01ChallengeAuthorization`] for this challenge
+    pub fn authorization(&self) -> Dns01ChallengeAuthorization {
+        Dns01ChallengeAuthorization::new(
+            self.state.identifier.identifier,
+            &self.challenge.token,
+            &self.state.account.key,
+        )
     }
 }
 
@@ -582,9 +587,9 @@ impl TlsAlpn01ChallengeHandle<'_> {
         &self.challenge.token
     }
 
-    /// Create a [`KeyAuthorization`] for this challenge
-    pub fn key_authorization(&self) -> KeyAuthorization {
-        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    /// Create a [`TlsAlpn01ChallengeAuthorization`] for this challenge
+    pub fn authorization(&self) -> TlsAlpn01ChallengeAuthorization {
+        TlsAlpn01ChallengeAuthorization::new(&self.challenge.token, &self.state.account.key)
     }
 }
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -13,10 +13,10 @@ use tokio::time::sleep;
 use crate::account::AccountInner;
 use crate::types::{
     Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Challenge,
-    ChallengeType, DeviceAttestation, Empty, FinalizeRequest, KeyAuthorization, OrderState,
-    OrderStatus, Problem,
+    ChallengeStatus, ChallengeType, DeviceAttestation, Empty, Error, FinalizeRequest,
+    KeyAuthorization, OrderState, OrderStatus, Problem,
 };
-use crate::{ChallengeStatus, Error, nonce_from_response, retry_after};
+use crate::{nonce_from_response, retry_after};
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -787,6 +787,41 @@ pub struct Http01Challenge {
     pub token: String,
 }
 
+/// Challenge authorization data for an RFC 8555 http-01 challenge
+pub struct Http01ChallengeAuthorization {
+    token: String,
+    key_auth: String,
+}
+
+impl Http01ChallengeAuthorization {
+    /// The path prefix defined by RFC 8555 for HTTP-01 challenge responses.
+    pub const PREFIX: &'static str = "/.well-known/acme-challenge/";
+
+    pub(crate) fn new(token: &str, key: &Key) -> Self {
+        Self {
+            token: token.to_owned(),
+            key_auth: format!("{token}.{}", &key.thumb),
+        }
+    }
+
+    /// The challenge token for this challenge authorization.
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    /// The path at which you should provision a file containing [`Self::key_authorization()`]
+    pub fn webroot_path(&self) -> String {
+        format!("{}{}", Self::PREFIX, self.token)
+    }
+
+    /// The key authorization content that should be placed in the challenge response file.
+    ///
+    /// The file should be provisioned at [`Self::webroot_path()`] in your webserver's web root.
+    pub fn key_authorization(&self) -> &str {
+        &self.key_auth
+    }
+}
+
 /// Challenge state for an RFC 8555 dns-01 challenge
 ///
 /// See <https://www.rfc-editor.org/rfc/rfc8555#section-8.4>
@@ -797,6 +832,45 @@ pub struct Dns01Challenge {
     pub token: String,
 }
 
+/// Challenge authorization data for an RFC 8555 http-01 challenge
+pub struct Dns01ChallengeAuthorization {
+    domain: String,
+    rdata: String,
+}
+
+impl Dns01ChallengeAuthorization {
+    /// The prefix added to the identifier value to form the TXT record host
+    pub const PREFIX: &'static str = "_acme-challenge.";
+
+    pub(crate) fn new(identifier: &Identifier, token: &str, key: &Key) -> Self {
+        let Identifier::Dns(domain) = identifier else {
+            unreachable!("DNS-01 only supports domain identifiers");
+        };
+
+        Self {
+            domain: domain.clone(),
+            rdata: BASE64_URL_SAFE_NO_PAD.encode(crypto::digest(
+                &crypto::SHA256,
+                format!("{token}.{}", &key.thumb).as_bytes(),
+            )),
+        }
+    }
+
+    /// Fully qualified hostname for the challenge response TXT record to be provisioned
+    ///
+    /// Includes a trailing dot.
+    pub fn host(&self) -> String {
+        format!("{}{}.", Self::PREFIX, self.domain)
+    }
+
+    /// The TXT record RDATA to provision for [`Self::host()`]
+    ///
+    /// This is the base64-encoded SHA256 digest of the challenge key authorization.
+    pub fn rdata(&self) -> &str {
+        &self.rdata
+    }
+}
+
 /// Challenge state for an RFC 8737 tls-alpn-01 challenge
 ///
 /// See <https://www.rfc-editor.org/rfc/rfc8737#section-3>
@@ -805,6 +879,43 @@ pub struct Dns01Challenge {
 pub struct TlsAlpn01Challenge {
     /// A token for constructing a key authorization to complete this challenge
     pub token: String,
+}
+
+/// Challenge authorization data for an RFC 8737 tls-alpn-01 challenge
+pub struct TlsAlpn01ChallengeAuthorization {
+    key_auth: String,
+    extension_value: Vec<u8>,
+}
+
+impl TlsAlpn01ChallengeAuthorization {
+    pub(crate) fn new(token: &str, key: &Key) -> Self {
+        let key_auth = format!("{token}.{}", &key.thumb);
+        Self {
+            extension_value: crypto::digest(&crypto::SHA256, key_auth.as_bytes())
+                .as_ref()
+                .to_vec(),
+            key_auth,
+        }
+    }
+
+    /// The unhashed key authorization string
+    ///
+    /// Typically, you would prefer using [`Self::extension_value`] to construct
+    /// a DER encoded id-pe-acmeIdentifier extension.
+    ///
+    /// This API may be useful when using a higher-level TLS-ALPN-01 certificate generation
+    /// API that expects the RFC-8555 §8.1 key authorization string as input.
+    pub fn key_authorization(&self) -> &str {
+        &self.key_auth
+    }
+
+    /// The SHA-256 digest of the RFC-8555 §8.1 key authorization string
+    ///
+    /// This can be used to construct a DER encoded id-pe-acmeIdentifier extension
+    /// for embedding in a provisioned TLS-ALPN-01 challenge response certificate.
+    pub fn extension_value(&self) -> &[u8] {
+        &self.extension_value
+    }
 }
 
 /// Status of an ACME [Challenge]
@@ -1042,47 +1153,6 @@ pub(crate) enum SigningAlgorithm {
     Es256,
     /// HMAC with SHA-256,
     Hs256,
-}
-
-/// A key authorization computed by combining a challenge token and the base64 account thumbprint
-///
-/// The HTTP-01, DNS-01 and TLS-ALPN-01 challenge types use this as part of provisioning a
-/// challenge response. See <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>.
-pub struct KeyAuthorization(String);
-
-impl KeyAuthorization {
-    pub(crate) fn new(token: &str, key: &Key) -> Self {
-        Self(format!("{token}.{}", &key.thumb))
-    }
-
-    /// Get the key authorization value
-    ///
-    /// This can be used for HTTP-01 challenge responses.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    /// Get the SHA-256 digest of the key authorization
-    ///
-    /// This can be used for TLS-ALPN-01 challenge responses.
-    ///
-    /// <https://datatracker.ietf.org/doc/html/rfc8737#section-3>
-    pub fn digest(&self) -> impl AsRef<[u8]> {
-        crypto::digest(&crypto::SHA256, self.0.as_bytes())
-    }
-
-    /// Get the base64-encoded SHA256 digest of the key authorization
-    ///
-    /// This can be used for DNS-01 challenge responses.
-    pub fn dns_value(&self) -> String {
-        BASE64_URL_SAFE_NO_PAD.encode(self.digest())
-    }
-}
-
-impl fmt::Debug for KeyAuthorization {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("KeyAuthorization").finish()
-    }
 }
 
 /// Attestation payload used for device-attest-01

--- a/src/types.rs
+++ b/src/types.rs
@@ -688,19 +688,89 @@ impl fmt::Display for AuthorizedIdentifier<'_> {
 /// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.5>
 #[derive(Debug, Deserialize)]
 pub struct Challenge {
-    /// Type of challenge
-    pub r#type: ChallengeType,
     /// Challenge identifier
     pub url: String,
-    /// Token for this challenge
-    ///
-    /// Unknown `ChallengeType` instances may omit this field, leaving it empty.
-    #[serde(default)]
-    pub token: String,
+    /// Challenge type specific state
+    #[serde(flatten)]
+    pub state: ChallengeState,
     /// Current status
     pub status: ChallengeStatus,
     /// Potential error state
     pub error: Option<Problem>,
+}
+
+/// Challenge type specific state
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ChallengeState {
+    /// State for an RFC 8555 HTTP-01 challenge
+    Http01(Http01Challenge),
+    /// State for an RFC 8555 DNS-01 challenge
+    Dns01(Dns01Challenge),
+    /// State for an RFC 8737 TLS-ALPN-01 challenge
+    TlsAlpn01(TlsAlpn01Challenge),
+    /// State for a draft-acme-device-attest-08 challenge
+    ///
+    /// Note: Device attestation support is experimental
+    DeviceAttest01,
+    /// An unknown challenge type
+    Unknown(String),
+}
+
+impl ChallengeState {
+    /// Get the challenge type associated with this challenge state
+    pub fn r#type(&self) -> ChallengeType {
+        match self {
+            Self::Http01(_) => ChallengeType::Http01,
+            Self::Dns01(_) => ChallengeType::Dns01,
+            Self::TlsAlpn01(_) => ChallengeType::TlsAlpn01,
+            Self::DeviceAttest01 => ChallengeType::DeviceAttest01,
+            Self::Unknown(r#type) => ChallengeType::Unknown(r#type.clone()),
+        }
+    }
+
+    /// Get the token associated with this challenge (if applicable)
+    ///
+    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a token. Other challenge types
+    /// do not rely on RFC 8555 key authorizations and will return `None`, expecting the
+    /// challenge to be satisfied with another method specific to its type.
+    pub fn token(&self) -> Option<&str> {
+        Some(match self {
+            Self::Http01(Http01Challenge { token })
+            | Self::Dns01(Dns01Challenge { token })
+            | Self::TlsAlpn01(TlsAlpn01Challenge { token }) => token,
+            Self::DeviceAttest01 | Self::Unknown { .. } => return None,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for ChallengeState {
+    // Deriving `Deserialize` for the `ChallengeState` enum w/ an untagged variant
+    // for unknown challenge types would mean we swallow deser errors for _known_
+    // challenge types. Instead, we want to deser the type string, and then either
+    // capture it as an `Unknown` variant, or dispatch the full value to a more specific
+    // challenge deser, propagating an error result if necessary.
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+
+        let r#type = value["type"]
+            .as_str()
+            .ok_or_else(|| de::Error::missing_field("type"))?;
+
+        match r#type {
+            "http-01" => serde_json::from_value(value)
+                .map(Self::Http01)
+                .map_err(de::Error::custom),
+            "dns-01" => serde_json::from_value(value)
+                .map(Self::Dns01)
+                .map_err(de::Error::custom),
+            "tls-alpn-01" => serde_json::from_value(value)
+                .map(Self::TlsAlpn01)
+                .map_err(de::Error::custom),
+            "device-attest-01" => Ok(Self::DeviceAttest01),
+            unknown_type => Ok(Self::Unknown(unknown_type.to_owned())),
+        }
+    }
 }
 
 /// The challenge type
@@ -719,6 +789,36 @@ pub enum ChallengeType {
     DeviceAttest01,
     #[serde(untagged)]
     Unknown(String),
+}
+
+/// Challenge state for an RFC 8555 http-01 challenge
+///
+/// See <https://www.rfc-editor.org/rfc/rfc8555#section-8.3>
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct Http01Challenge {
+    /// A token for constructing a key authorization to complete this challenge
+    pub token: String,
+}
+
+/// Challenge state for an RFC 8555 dns-01 challenge
+///
+/// See <https://www.rfc-editor.org/rfc/rfc8555#section-8.4>
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct Dns01Challenge {
+    /// A token for constructing a key authorization to complete this challenge
+    pub token: String,
+}
+
+/// Challenge state for an RFC 8737 tls-alpn-01 challenge
+///
+/// See <https://www.rfc-editor.org/rfc/rfc8737#section-3>
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct TlsAlpn01Challenge {
+    /// A token for constructing a key authorization to complete this challenge
+    pub token: String,
 }
 
 /// Status of an ACME [Challenge]
@@ -958,11 +1058,10 @@ pub(crate) enum SigningAlgorithm {
     Hs256,
 }
 
-/// The response value to use for challenge responses
+/// A key authorization computed by combining a challenge token and the base64 account thumbprint
 ///
-/// Refer to the methods below to see which encoding to use for your challenge type.
-///
-/// <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>
+/// The HTTP-01, DNS-01 and TLS-ALPN-01 challenge types use this as part of provisioning a
+/// challenge response. See <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>.
 pub struct KeyAuthorization(String);
 
 impl KeyAuthorization {
@@ -1093,10 +1192,13 @@ mod tests {
         }"#;
 
         let obj = serde_json::from_str::<Challenge>(CHALLENGE).unwrap();
-        assert_eq!(obj.r#type, ChallengeType::Dns01);
+        assert_eq!(obj.state.r#type(), ChallengeType::Dns01);
         assert_eq!(obj.url, "https://example.com/acme/chall/Rg5dV14Gh1Q");
         assert_eq!(obj.status, ChallengeStatus::Pending);
-        assert_eq!(obj.token, "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA");
+        assert_eq!(
+            obj.state.token(),
+            Some("evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA")
+        );
     }
 
     // https://datatracker.ietf.org/doc/html/rfc8555#section-7.6

--- a/src/types.rs
+++ b/src/types.rs
@@ -728,20 +728,6 @@ impl ChallengeState {
             Self::Unknown(r#type) => ChallengeType::Unknown(r#type.clone()),
         }
     }
-
-    /// Get the token associated with this challenge (if applicable)
-    ///
-    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a token. Other challenge types
-    /// do not rely on RFC 8555 key authorizations and will return `None`, expecting the
-    /// challenge to be satisfied with another method specific to its type.
-    pub fn token(&self) -> Option<&str> {
-        Some(match self {
-            Self::Http01(Http01Challenge { token })
-            | Self::Dns01(Dns01Challenge { token })
-            | Self::TlsAlpn01(TlsAlpn01Challenge { token }) => token,
-            Self::DeviceAttest01 | Self::Unknown { .. } => return None,
-        })
-    }
 }
 
 impl<'de> Deserialize<'de> for ChallengeState {
@@ -1195,9 +1181,13 @@ mod tests {
         assert_eq!(obj.state.r#type(), ChallengeType::Dns01);
         assert_eq!(obj.url, "https://example.com/acme/chall/Rg5dV14Gh1Q");
         assert_eq!(obj.status, ChallengeStatus::Pending);
+
+        let ChallengeState::Dns01(chall_state) = obj.state else {
+            panic!("wrong challenge state type");
+        };
         assert_eq!(
-            obj.state.token(),
-            Some("evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA")
+            chall_state.token,
+            "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA",
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -323,26 +323,6 @@ struct JwkThumb<'a> {
     y: &'a str,
 }
 
-/// An ACME challenge as described in RFC 8555 (section 7.1.5)
-///
-/// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.5>
-#[derive(Debug, Deserialize)]
-pub struct Challenge {
-    /// Type of challenge
-    pub r#type: ChallengeType,
-    /// Challenge identifier
-    pub url: String,
-    /// Token for this challenge
-    ///
-    /// Unknown `ChallengeType` instances may omit this field, leaving it empty.
-    #[serde(default)]
-    pub token: String,
-    /// Current status
-    pub status: ChallengeStatus,
-    /// Potential error state
-    pub error: Option<Problem>,
-}
-
 /// Contents of an ACME order as described in RFC 8555 (section 7.1.3)
 ///
 /// The order identity will usually be represented by an [Order](crate::Order).
@@ -639,19 +619,6 @@ impl AuthorizationState {
     }
 }
 
-/// Status for an [`AuthorizationState`]
-#[allow(missing_docs)]
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub enum AuthorizationStatus {
-    Pending,
-    Valid,
-    Invalid,
-    Revoked,
-    Expired,
-    Deactivated,
-}
-
 /// Represent an identifier in an ACME [Order](crate::Order)
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -716,6 +683,26 @@ impl fmt::Display for AuthorizedIdentifier<'_> {
     }
 }
 
+/// An ACME challenge as described in RFC 8555 (section 7.1.5)
+///
+/// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.5>
+#[derive(Debug, Deserialize)]
+pub struct Challenge {
+    /// Type of challenge
+    pub r#type: ChallengeType,
+    /// Challenge identifier
+    pub url: String,
+    /// Token for this challenge
+    ///
+    /// Unknown `ChallengeType` instances may omit this field, leaving it empty.
+    #[serde(default)]
+    pub token: String,
+    /// Current status
+    pub status: ChallengeStatus,
+    /// Potential error state
+    pub error: Option<Problem>,
+}
+
 /// The challenge type
 #[allow(missing_docs)]
 #[non_exhaustive]
@@ -743,6 +730,19 @@ pub enum ChallengeStatus {
     Processing,
     Valid,
     Invalid,
+}
+
+/// Status for an [`AuthorizationState`]
+#[allow(missing_docs)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum AuthorizationStatus {
+    Pending,
+    Valid,
+    Invalid,
+    Revoked,
+    Expired,
+    Deactivated,
 }
 
 /// Status of an [Order](crate::Order)

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{self, Write};
 use std::net::IpAddr;
+use std::slice::Iter;
+use std::str::FromStr;
 use std::time::Instant;
 
 use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine};
@@ -43,6 +45,9 @@ pub enum Error {
     #[cfg(feature = "hyper-rustls")]
     #[error("HTTP request failure: {0}")]
     Hyper(#[from] hyper::Error),
+    /// Invalid DNS-persist-01 challenge type issuer domain(s)
+    #[error("DNS-persist-01 challenge issuer domain name(s) invalid: {0}")]
+    InvalidIssuerDomains(String),
     /// Invalid ACME server URL
     #[error("invalid URI: {0}")]
     InvalidUri(#[from] http::uri::InvalidUri),
@@ -658,7 +663,7 @@ impl Identifier {
 
 /// An [`Identifier`] which knows its `wildcard` context
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AuthorizedIdentifier<'a> {
     /// The source identifier, missing any wildcard context
     pub identifier: &'a Identifier,
@@ -707,6 +712,10 @@ pub enum ChallengeState {
     Http01(Http01Challenge),
     /// State for an RFC 8555 DNS-01 challenge
     Dns01(Dns01Challenge),
+    /// State for a draft-ietf-acme-dns-persist challenge
+    ///
+    /// Note: DNS persist challenge support is experimental
+    DnsPersist01(DnsPersist01Challenge),
     /// State for an RFC 8737 TLS-ALPN-01 challenge
     TlsAlpn01(TlsAlpn01Challenge),
     /// State for a draft-acme-device-attest-08 challenge
@@ -723,6 +732,7 @@ impl ChallengeState {
         match self {
             Self::Http01(_) => ChallengeType::Http01,
             Self::Dns01(_) => ChallengeType::Dns01,
+            Self::DnsPersist01(_) => ChallengeType::DnsPersist01,
             Self::TlsAlpn01(_) => ChallengeType::TlsAlpn01,
             Self::DeviceAttest01 => ChallengeType::DeviceAttest01,
             Self::Unknown(r#type) => ChallengeType::Unknown(r#type.clone()),
@@ -750,6 +760,9 @@ impl<'de> Deserialize<'de> for ChallengeState {
             "dns-01" => serde_json::from_value(value)
                 .map(Self::Dns01)
                 .map_err(de::Error::custom),
+            "dns-persist-01" => serde_json::from_value(value)
+                .map(Self::DnsPersist01)
+                .map_err(de::Error::custom),
             "tls-alpn-01" => serde_json::from_value(value)
                 .map(Self::TlsAlpn01)
                 .map_err(de::Error::custom),
@@ -768,6 +781,8 @@ pub enum ChallengeType {
     Http01,
     #[serde(rename = "dns-01")]
     Dns01,
+    #[serde(rename = "dns-persist-01")]
+    DnsPersist01,
     #[serde(rename = "tls-alpn-01")]
     TlsAlpn01,
     /// Note: Device attestation support is experimental
@@ -915,6 +930,223 @@ impl TlsAlpn01ChallengeAuthorization {
     /// for embedding in a provisioned TLS-ALPN-01 challenge response certificate.
     pub fn extension_value(&self) -> &[u8] {
         &self.extension_value
+    }
+}
+
+/// Challenge state for draft-ietf-acme-dns-persist dns-persist-01 challenges
+///
+/// Note: DNS persist challenge support is experimental
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct DnsPersist01Challenge {
+    /// The list of issuer domain names accepted by the CA
+    pub issuer_domain_names: IssuerDomainNames,
+}
+
+/// Issuer names for a [`ChallengeType::DnsPersist01`] challenge.
+///
+/// One or more (to a limit of 10) normalized issuer domain names provided
+/// by the ACME server.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IssuerDomainNames(Vec<IssuerDomainName>);
+
+impl IssuerDomainNames {
+    /// Servers MUST NOT send more than 10 issuer domain names.
+    ///
+    /// See <https://datatracker.ietf.org/doc/html/draft-ietf-acme-dns-persist-00#section-3.1>
+    pub const MAX_COUNT: usize = 10;
+
+    /// Create a new `IssuerDomainNames` collection.
+    ///
+    /// Returns an error if the collection is empty or contains more than
+    /// [`Self::MAX_COUNT`] elements.
+    pub fn new(names: Vec<IssuerDomainName>) -> Result<Self, Error> {
+        if names.is_empty() {
+            return Err(Error::InvalidIssuerDomains(
+                "no issuer domains provided".to_owned(),
+            ));
+        }
+        if names.len() > Self::MAX_COUNT {
+            return Err(Error::InvalidIssuerDomains(format!(
+                "too many issuer domains provided: {sent} > {max}",
+                sent = names.len(),
+                max = Self::MAX_COUNT
+            )));
+        }
+        Ok(Self(names))
+    }
+
+    /// Returns the number of issuer domain names
+    #[allow(clippy::len_without_is_empty)] // Type system ensures it is never empty.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns an iterator over the issuer domain names
+    pub fn iter(&self) -> impl Iterator<Item = &IssuerDomainName> {
+        self.0.iter()
+    }
+}
+
+impl AsRef<[IssuerDomainName]> for IssuerDomainNames {
+    fn as_ref(&self) -> &[IssuerDomainName] {
+        &self.0
+    }
+}
+
+impl<'a> IntoIterator for &'a IssuerDomainNames {
+    type Item = &'a IssuerDomainName;
+    type IntoIter = Iter<'a, IssuerDomainName>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'de> Deserialize<'de> for IssuerDomainNames {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Self::new(Vec::<IssuerDomainName>::deserialize(deserializer)?).map_err(de::Error::custom)
+    }
+}
+
+/// A normalized issuer name for a [`ChallengeType::DnsPersist01`] challenge.
+///
+/// Each issuer name is an A-label format (e.g. ASCII-only), all lowercase,
+/// domain name that is no longer than 253 octets and has no trailing dot.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct IssuerDomainName(String);
+
+impl IssuerDomainName {
+    /// Each domain name MUST NOT exceed 253 octets in length.
+    ///
+    /// See <https://datatracker.ietf.org/doc/html/draft-ietf-acme-dns-persist-00#section-3.1>
+    pub const MAX_LEN: usize = 253;
+
+    /// Create a new `IssuerDomainName` from a string.
+    ///
+    /// Returns an error if the string does not conform to the normalization
+    /// requirements.
+    pub fn new(s: &str) -> Result<Self, Error> {
+        if s.len() > Self::MAX_LEN {
+            return Err(Error::InvalidIssuerDomains(format!(
+                "issuer name was too long: {len} > {max}",
+                len = s.len(),
+                max = Self::MAX_LEN
+            )));
+        }
+
+        if s.is_empty() {
+            return Err(Error::InvalidIssuerDomains(
+                "issuer name was empty".to_owned(),
+            ));
+        }
+
+        // The domain name MUST NOT have a trailing dot.
+        if s.ends_with('.') {
+            return Err(Error::InvalidIssuerDomains(
+                "issuer name had a trailing dot".to_owned(),
+            ));
+        }
+
+        for byte in s.bytes() {
+            // The domain name MUST be represented in A-label format.
+            if !byte.is_ascii() {
+                return Err(Error::InvalidIssuerDomains(
+                    "issuer name was not in A-label format".to_owned(),
+                ));
+            }
+            // All characters MUST be lowercase.
+            if byte.is_ascii_uppercase() {
+                return Err(Error::InvalidIssuerDomains(
+                    "issuer name was not all lowercase".to_owned(),
+                ));
+            }
+        }
+
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl AsRef<str> for IssuerDomainName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for IssuerDomainName {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for IssuerDomainName {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Self::new(&String::deserialize(deserializer)?).map_err(de::Error::custom)
+    }
+}
+
+/// A challenge response TXT record for dns-persist-01 validation
+///
+/// This struct represents the complete DNS TXT record that should be provisioned
+/// in an authoritative DNS zone to complete a dns-persist-01 challenge.
+///
+/// The RDATA is stored as a vector of strings, where each string is at most 255
+/// octets as required by RFC 1035 Section 3.3.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DnsPersist01ChallengeAuthorization {
+    name: String,
+    rdata: Vec<String>,
+}
+
+impl DnsPersist01ChallengeAuthorization {
+    /// The prefix added to the identifier value to form the TXT record host
+    pub const PREFIX: &'static str = "_acme-challenge.";
+
+    /// Maximum length of a single character-string in DNS TXT RDATA (RFC 1035 Section 3.3)
+    const MAX_CHAR_STRING_LEN: usize = 255;
+
+    /// Create a new `DnsPersist01ChallengeAuthorization` from an identifier and raw RDATA string.
+    ///
+    /// The name is formatted with the `_validation-persist.` prefix, and the RDATA
+    /// is automatically split into chunks of at most 255 octets.
+    pub(crate) fn new(identifier: &Identifier, rdata: &str) -> Self {
+        let Identifier::Dns(domain) = identifier else {
+            unreachable!("dns-persist-01 requires DNS identifier");
+        };
+        Self {
+            name: format!("_validation-persist.{domain}"),
+            rdata: Self::split_into_chunks(rdata),
+        }
+    }
+
+    /// The fully qualified DNS record hostname (e.g., `_validation-persist.example.com`)
+    ///
+    /// Includes a trailing dot.
+    pub fn hostname(&self) -> &str {
+        &self.name
+    }
+
+    /// The DNS TXT record RDATA as a slice of character-strings.
+    ///
+    /// Each string is at most 255 octets as required by RFC 1035 Section 3.3.
+    /// When the total RDATA exceeds 255 octets, it is split into multiple strings.
+    pub fn rdata(&self) -> &[String] {
+        &self.rdata
+    }
+
+    /// Split a value into chunks of at most 255 bytes.
+    fn split_into_chunks(value: &str) -> Vec<String> {
+        value
+            .as_bytes()
+            .chunks(Self::MAX_CHAR_STRING_LEN)
+            .map(|chunk| {
+                std::str::from_utf8(chunk)
+                    .unwrap(/* Safety: DnsPersist01RecordBuilder verifies inputs are ASCII*/)
+                    .to_owned()
+            })
+            .collect()
     }
 }
 
@@ -1443,5 +1675,83 @@ mod tests {
         let window = info.suggested_window;
         assert_eq!(window.start.day(), 2);
         assert_eq!(window.end.day(), 3);
+    }
+
+    #[test]
+    fn valid_issuer_domains() {
+        let names = IssuerDomainNames::new(vec!["authority.example".parse().unwrap()]).unwrap();
+        assert_eq!(names.len(), 1);
+
+        let names = IssuerDomainNames::new(
+            (0..10)
+                .map(|i| format!("ca{i}.example").parse().unwrap())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+        assert_eq!(names.len(), 10);
+    }
+
+    #[test]
+    fn invalid_issuer_domains() {
+        assert!(
+            IssuerDomainNames::new(vec![])
+                .unwrap_err()
+                .to_string()
+                .contains("no issuer domains")
+        );
+
+        assert!(
+            IssuerDomainNames::new(
+                (0..IssuerDomainNames::MAX_COUNT + 1)
+                    .map(|i| format!("ca{i}.example").parse().unwrap())
+                    .collect::<Vec<_>>()
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("too many")
+        );
+    }
+
+    #[test]
+    fn dns_persist_challenge_valid_deserialization() {
+        // <https://datatracker.ietf.org/doc/html/draft-ietf-acme-dns-persist-00#section-3.1>
+        const CHALLENGE: &str = r#"{
+              "type": "dns-persist-01",
+              "url": "https://ca.example/acme/authz/1234/0",
+              "status": "pending",
+              "issuer-domain-names": ["authority.example", "ca.example.net"]
+            }"#;
+
+        let obj = serde_json::from_str::<Challenge>(CHALLENGE).unwrap();
+        assert_eq!(obj.status, ChallengeStatus::Pending);
+        assert_eq!(obj.state.r#type(), ChallengeType::DnsPersist01);
+        assert_eq!(obj.url, "https://ca.example/acme/authz/1234/0");
+
+        let ChallengeState::DnsPersist01(challenge) = &obj.state else {
+            panic!("unexpected challenge state");
+        };
+
+        assert_eq!(challenge.issuer_domain_names.len(), 2);
+        assert_eq!(
+            challenge.issuer_domain_names.as_ref()[0].as_ref(),
+            "authority.example"
+        );
+        assert_eq!(
+            challenge.issuer_domain_names.as_ref()[1].as_ref(),
+            "ca.example.net"
+        );
+    }
+
+    #[test]
+    fn dns_persist_challenge_invalid_deserialization() {
+        const CHALLENGE: &str = r#"{
+              "type": "dns-persist-01",
+              "url": "https://ca.example/acme/authz/1234/0",
+              "status": "pending",
+              "issuer-domain-names": ["a.ex","b.ex","c.ex","d.ex","e.ex","f.ex","g.ex","h.ex","i.ex","j.ex","k.ex"]
+            }"#;
+
+        let err = serde_json::from_str::<Challenge>(CHALLENGE).unwrap_err();
+        assert!(err.to_string().contains("too many"), "error was: {err}");
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,8 +18,8 @@ use x509_parser::extensions::ParsedExtension;
 #[cfg(feature = "x509-parser")]
 use x509_parser::parse_x509_certificate;
 
-use crate::BytesResponse;
 use crate::crypto::{self, KeyPair};
+use crate::{BytesResponse, Key};
 
 /// Error type for instant-acme
 #[derive(Debug, Error)]
@@ -956,6 +956,48 @@ pub(crate) enum SigningAlgorithm {
     Es256,
     /// HMAC with SHA-256,
     Hs256,
+}
+
+/// The response value to use for challenge responses
+///
+/// Refer to the methods below to see which encoding to use for your challenge type.
+///
+/// <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>
+pub struct KeyAuthorization(String);
+
+impl KeyAuthorization {
+    pub(crate) fn new(token: &str, key: &Key) -> Self {
+        Self(format!("{token}.{}", &key.thumb))
+    }
+
+    /// Get the key authorization value
+    ///
+    /// This can be used for HTTP-01 challenge responses.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Get the SHA-256 digest of the key authorization
+    ///
+    /// This can be used for TLS-ALPN-01 challenge responses.
+    ///
+    /// <https://datatracker.ietf.org/doc/html/rfc8737#section-3>
+    pub fn digest(&self) -> impl AsRef<[u8]> {
+        crypto::digest(&crypto::SHA256, self.0.as_bytes())
+    }
+
+    /// Get the base64-encoded SHA256 digest of the key authorization
+    ///
+    /// This can be used for DNS-01 challenge responses.
+    pub fn dns_value(&self) -> String {
+        BASE64_URL_SAFE_NO_PAD.encode(self.digest())
+    }
+}
+
+impl fmt::Debug for KeyAuthorization {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("KeyAuthorization").finish()
+    }
 }
 
 /// Attestation payload used for device-attest-01

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -648,7 +648,7 @@ impl Environment {
                 .challenge(A::TYPE)
                 .ok_or_else(|| format!("no {:?} challenge found", A::TYPE))?;
 
-            let key_authz = challenge.key_authorization();
+            let key_authz = challenge.key_authorization().unwrap();
             self.request_challenge::<A>(&challenge, &key_authz).await?;
 
             debug!(challenge_url = challenge.url, "marking challenge ready");
@@ -787,7 +787,7 @@ impl AuthorizationMethod for Http01 {
         key_auth: &'a KeyAuthorization,
     ) -> impl Serialize + 'a {
         debug!(
-            token = challenge.token,
+            token = challenge.state.token(),
             key_auth = key_auth.as_str(),
             "provisioning HTTP-01 response",
         );
@@ -799,7 +799,7 @@ impl AuthorizationMethod for Http01 {
         }
 
         AddHttp01Request {
-            token: &challenge.token,
+            token: challenge.state.token().unwrap(),
             content: key_auth.as_str(),
         }
     }

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -79,6 +79,223 @@ async fn dns_01() -> Result<(), Box<dyn StdError>> {
         .map(|_| ())
 }
 
+/// Test dns-persist-01 challenge persistence behavior
+///
+/// This test verifies that a dns-persist-01 TXT record can be reused across multiple
+/// certificate issuances without re-provisioning, demonstrating the "persistence" aspect
+/// of the challenge type.
+#[tokio::test]
+#[ignore]
+async fn dns_persist_01() -> Result<(), Box<dyn StdError>> {
+    try_tracing_init();
+    dns_persist_01_test(DnsPersist01TestConfig {
+        first_identifier: "dns-persist01.example.com",
+        second_identifier: "dns-persist01.example.com",
+        ..Default::default()
+    })
+    .await
+}
+
+/// Test dns-persist-01 wildcard policy behavior
+///
+/// This test verifies that a dns-persist-01 TXT record with the wildcard policy set
+/// can be used to issue wildcard certificates for the validated domain without
+/// re-provisioning.
+#[tokio::test]
+#[ignore]
+async fn dns_persist_01_wildcard() -> Result<(), Box<dyn StdError>> {
+    try_tracing_init();
+    // First validate dns-persist01.example.com with wildcard policy,
+    // then issue for *.dns-persist01.example.com using the same TXT record.
+    dns_persist_01_test(DnsPersist01TestConfig {
+        first_identifier: "dns-persist01.example.com",
+        second_identifier: "*.dns-persist01.example.com",
+        wildcard_policy: true,
+        ..Default::default()
+    })
+    .await
+}
+
+/// Test dns-persist-01 with long RDATA that must be split across multiple TXT strings
+///
+/// DNS TXT record strings have a 255 byte limit. This test verifies that the library
+/// correctly handles RDATA that exceeds this limit by splitting it into multiple strings.
+#[tokio::test]
+#[ignore]
+async fn dns_persist_01_long_rdata() -> Result<(), Box<dyn StdError>> {
+    try_tracing_init();
+
+    // Create a long issuer domain name that will cause the RDATA to exceed 255 bytes.
+    // Format: "{issuer}; accounturi={account_uri}" where account_uri is ~60 chars.
+    // We need issuer + ~75 chars overhead > 255, so issuer should be > 180 chars.
+    let long_issuer = format!(
+        "{}.{}.{}.long-issuer.example",
+        "a".repeat(60),
+        "b".repeat(60),
+        "c".repeat(60)
+    );
+    assert!(long_issuer.len() > 180, "issuer should be long enough");
+
+    dns_persist_01_test(DnsPersist01TestConfig {
+        first_identifier: "long-rdata.example.com",
+        second_identifier: "long-rdata.example.com",
+        caa_identities: vec![long_issuer],
+        assert_rdata_split: true,
+        ..Default::default()
+    })
+    .await
+}
+
+/// Configuration for dns-persist-01 persistence tests
+#[derive(Default)]
+struct DnsPersist01TestConfig {
+    /// The identifier to use for the first order (provisions the TXT record)
+    first_identifier: &'static str,
+    /// The identifier to use for the second order (reuses the TXT record)
+    second_identifier: &'static str,
+    /// Whether to set the wildcard policy flag on the TXT record
+    wildcard_policy: bool,
+    /// Custom CAA identities (issuer domain names) for the Pebble config
+    caa_identities: Vec<String>,
+    /// Assert that the RDATA was split into multiple TXT strings
+    assert_rdata_split: bool,
+}
+
+/// Common test logic for dns-persist-01 persistence tests
+async fn dns_persist_01_test(config: DnsPersist01TestConfig) -> Result<(), Box<dyn StdError>> {
+    // Disable authz reuse to ensure we're testing dns-persist-01 persistence,
+    // not ACME server-side authorization reuse.
+    let mut env_config = EnvironmentConfig {
+        authz_reuse: 0,
+        ..EnvironmentConfig::default()
+    };
+    env_config.pebble.caa_identities = config.caa_identities;
+    let env = Environment::new(env_config).await?;
+
+    let first_identifiers = dns_identifiers([config.first_identifier]);
+    let first_order = NewOrder::new(&first_identifiers);
+
+    // First issuance: provision the TXT record and complete the challenge.
+    debug!("creating first order");
+    let mut order = env.account.new_order(&first_order).await?;
+    info!(order_url = order.url(), "created first order");
+
+    let mut authorizations = order.authorizations();
+    while let Some(result) = authorizations.next().await {
+        let mut authz = result?;
+        assert_eq!(
+            authz.status,
+            AuthorizationStatus::Pending,
+            "first order authz should be pending"
+        );
+
+        let mut dns_chall = authz
+            .dns_persist01()
+            .ok_or("no dns-persist-01 challenge found")?;
+
+        // Build the TXT record with the first issuer
+        let issuer = dns_chall
+            .issuer_domain_names()
+            .iter()
+            .next()
+            .ok_or("no issuer domain names in challenge")?;
+
+        let builder = dns_chall.response_txt_record(issuer)?;
+        let record = if config.wildcard_policy {
+            builder.wildcard().build()
+        } else {
+            builder.build()
+        };
+
+        // Verify RDATA was split if expected
+        let rdata = record.rdata();
+        if config.assert_rdata_split {
+            assert!(
+                rdata.len() > 1,
+                "expected RDATA to be split into multiple chunks, got {} chunk(s)",
+                rdata.len()
+            );
+        }
+
+        let host = record.hostname();
+        let value = rdata.join("");
+        debug!(
+            host,
+            value,
+            rdata_chunks = rdata.len(),
+            wildcard_policy = config.wildcard_policy,
+            "provisioning dns-persist-01 response for first order"
+        );
+
+        // Provision the TXT record in challtestsrv
+        #[derive(Serialize)]
+        struct SetTxtRequest {
+            host: String,
+            value: String,
+        }
+        let body = serde_json::to_vec(&SetTxtRequest {
+            host: host.to_owned(),
+            value,
+        })?;
+        let url = format!("http://[::1]:{}/set-txt", env.config.challtestsrv_port);
+        env.client
+            .request(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(url)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(BodyWrapper::from(body))?,
+            )
+            .await?;
+
+        debug!("marking first order challenge ready");
+        dns_chall.set_ready().await?;
+    }
+
+    // Poll until the first order is ready and issue the certificate
+    let status = order.poll_ready(&RETRY_POLICY).await?;
+    assert_eq!(status, OrderStatus::Ready, "first order should be ready");
+    let _first_cert = env.certificate(&mut order).await?;
+    info!("first certificate issued successfully");
+
+    // Second issuance: reuse the same TXT record without re-provisioning
+    let second_identifiers = dns_identifiers([config.second_identifier]);
+    let second_order = NewOrder::new(&second_identifiers);
+
+    debug!(config.second_identifier, "creating second order");
+    let mut order = env.account.new_order(&second_order).await?;
+    info!(order_url = order.url(), "created second order");
+
+    let mut authorizations = order.authorizations();
+    while let Some(result) = authorizations.next().await {
+        let mut authz = result?;
+
+        // The authz should be PENDING, not VALID (which would indicate server-side reuse)
+        assert_eq!(
+            authz.status,
+            AuthorizationStatus::Pending,
+            "second order authz should be pending (not reused by server)"
+        );
+
+        let mut dns_chall = authz
+            .dns_persist01()
+            .ok_or("no dns-persist-01 challenge found in second order")?;
+
+        // Do NOT re-provision the TXT record - the persistence mechanism means
+        // the previous record should still be valid for this new challenge.
+        debug!("marking second order challenge ready WITHOUT re-provisioning TXT record");
+        dns_chall.set_ready().await?;
+    }
+
+    // Poll until the second order is ready and issue the certificate
+    let status = order.poll_ready(&RETRY_POLICY).await?;
+    assert_eq!(status, OrderStatus::Ready, "second order should be ready");
+    let _second_cert = env.certificate(&mut order).await?;
+    info!("second certificate issued successfully using persisted TXT record");
+
+    Ok(())
+}
+
 #[tokio::test]
 #[ignore]
 async fn tls_alpn_01() -> Result<(), Box<dyn StdError>> {
@@ -949,6 +1166,11 @@ struct PebbleConfig {
     domain_blocklist: Vec<&'static str>,
     retry_after: RetryConfig,
     profiles: HashMap<&'static str, Profile>,
+    /// CAA identities returned in dns-persist-01 challenges as issuerDomainNames
+    ///
+    /// Defaults to `["pebble.letsencrypt.org"]` if empty/unset.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    caa_identities: Vec<String>,
 }
 
 impl Default for PebbleConfig {
@@ -988,6 +1210,7 @@ impl Default for PebbleConfig {
                 ),
             ]
             .into(),
+            caa_identities: Vec::new(),
         }
     }
 }

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::error::Error as StdError;
+use std::future::Future;
 use std::io::{self, Read};
 use std::net::IpAddr;
 use std::path::Path;
@@ -24,9 +25,8 @@ use hyper_util::client::legacy::Client as HyperClient;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
 use instant_acme::{
-    Account, AuthorizationStatus, BodyWrapper, ChallengeHandle, ChallengeType, Error,
-    ExternalAccountKey, Identifier, Key, KeyAuthorization, NewAccount, NewOrder, Order,
-    OrderStatus, RetryPolicy,
+    Account, AuthorizationHandle, AuthorizationStatus, BodyWrapper, Error, ExternalAccountKey,
+    Identifier, Key, NewAccount, NewOrder, Order, OrderStatus, RetryPolicy,
 };
 #[cfg(all(feature = "time", feature = "x509-parser"))]
 use instant_acme::{CertificateIdentifier, RevocationRequest};
@@ -644,15 +644,7 @@ impl Environment {
                 _ => unreachable!("unexpected authz state: {:?}", authz.status),
             }
 
-            let mut challenge = authz
-                .challenge(A::TYPE)
-                .ok_or_else(|| format!("no {:?} challenge found", A::TYPE))?;
-
-            let key_authz = challenge.key_authorization().unwrap();
-            self.request_challenge::<A>(&challenge, &key_authz).await?;
-
-            debug!(challenge_url = challenge.url, "marking challenge ready");
-            challenge.set_ready().await?;
+            A::handle_challenge(&mut authz, &self.client, self.config.challtestsrv_port).await?;
         }
 
         // Poll until the order is ready.
@@ -751,25 +743,6 @@ impl Environment {
         assert_eq!(roots.len(), 1);
         Ok(roots)
     }
-
-    async fn request_challenge<'a, A: AuthorizationMethod>(
-        &self,
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &KeyAuthorization,
-    ) -> Result<(), Box<dyn StdError>> {
-        let url = format!("http://[::1]:{}/{}", self.config.challtestsrv_port, A::PATH);
-        let body = serde_json::to_vec(&A::authz_request(challenge, key_auth))?;
-        self.client
-            .request(
-                Request::builder()
-                    .method(Method::POST)
-                    .uri(url)
-                    .header(CONTENT_TYPE, "application/json")
-                    .body(BodyWrapper::from(body))?,
-            )
-            .await?;
-        Ok(())
-    }
 }
 
 fn dns_identifiers(dns_names: impl IntoIterator<Item = impl ToString>) -> Vec<Identifier> {
@@ -782,12 +755,17 @@ fn dns_identifiers(dns_names: impl IntoIterator<Item = impl ToString>) -> Vec<Id
 struct Http01;
 
 impl AuthorizationMethod for Http01 {
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a {
+    async fn handle_challenge<'a>(
+        authz: &'a mut AuthorizationHandle<'a>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> Result<(), Box<dyn StdError>> {
+        let mut http_chall = authz.http01().expect("missing HTTP-01 challenge");
+        let token = http_chall.token();
+        let key_auth = http_chall.key_authorization();
+
         debug!(
-            token = challenge.state.token(),
+            token,
             key_auth = key_auth.as_str(),
             "provisioning HTTP-01 response",
         );
@@ -798,31 +776,45 @@ impl AuthorizationMethod for Http01 {
             content: &'a str,
         }
 
-        AddHttp01Request {
-            token: challenge.state.token().unwrap(),
+        let body = serde_json::to_vec(&AddHttp01Request {
+            token,
             content: key_auth.as_str(),
-        }
-    }
+        })?;
+        let url = format!("http://[::1]:{challtestsrv_port}/add-http01");
+        client
+            .request(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(url)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(BodyWrapper::from(body))?,
+            )
+            .await?;
 
-    const PATH: &str = "add-http01";
-    const TYPE: ChallengeType = ChallengeType::Http01;
+        debug!("marking challenge ready");
+        http_chall.set_ready().await?;
+        Ok(())
+    }
 }
 
 struct Dns01;
 
 impl AuthorizationMethod for Dns01 {
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'_>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a {
-        let identifier = challenge.identifier();
+    async fn handle_challenge<'a>(
+        authz: &'a mut AuthorizationHandle<'a>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> Result<(), Box<dyn StdError>> {
+        let mut dns_chall = authz.dns01().expect("missing DNS-01 challenge");
+        let key_auth = dns_chall.key_authorization().dns_value();
+        let identifier = dns_chall.identifier();
+
         let Identifier::Dns(domain) = identifier.identifier else {
             unreachable!("unsupported identifier {identifier:?}");
         };
 
         let host = format!("_acme-challenge.{domain}.");
-        let value = key_auth.dns_value();
-        debug!(host, value, "provisioning DNS-01 response");
+        debug!(host, key_auth, "provisioning DNS-01 response");
 
         #[derive(Serialize)]
         struct AddDns01Request {
@@ -830,22 +822,41 @@ impl AuthorizationMethod for Dns01 {
             value: String,
         }
 
-        AddDns01Request { host, value }
-    }
+        let body = serde_json::to_vec(&AddDns01Request {
+            host,
+            value: key_auth,
+        })?;
+        let url = format!("http://[::1]:{challtestsrv_port}/set-txt");
+        client
+            .request(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(url)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(BodyWrapper::from(body))?,
+            )
+            .await?;
 
-    const PATH: &str = "set-txt";
-    const TYPE: ChallengeType = ChallengeType::Dns01;
+        debug!("marking challenge ready");
+        dns_chall.set_ready().await?;
+        Ok(())
+    }
 }
 
 struct Alpn01;
 
 impl AuthorizationMethod for Alpn01 {
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a {
+    async fn handle_challenge<'a>(
+        authz: &'a mut AuthorizationHandle<'a>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> Result<(), Box<dyn StdError>> {
+        let mut tls_chall = authz.tls_alpn01().expect("missing TLS-ALPN-01 challenge");
+        let key_auth = tls_chall.key_authorization();
+        let identifier = tls_chall.identifier();
+
         debug!(
-            identifier = %challenge.identifier(),
+            %identifier,
             key_auth = key_auth.as_str(),
             "provisioning TLS-ALPN-01 response",
         );
@@ -856,28 +867,40 @@ impl AuthorizationMethod for Alpn01 {
             content: &'a str,
         }
 
-        AddAlpn01Request {
-            host: challenge.identifier().to_string(),
+        let body = serde_json::to_vec(&AddAlpn01Request {
+            host: identifier.to_string(),
             // Note: pebble-challtestsrv wants to hash the key auth itself, so we
             // don't use key_auth.digest() here.
             content: key_auth.as_str(),
-        }
-    }
+        })?;
+        let url = format!("http://[::1]:{}/add-tlsalpn01", challtestsrv_port);
+        client
+            .request(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(url)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(BodyWrapper::from(body))?,
+            )
+            .await?;
 
-    const PATH: &str = "add-tlsalpn01";
-    const TYPE: ChallengeType = ChallengeType::TlsAlpn01;
+        debug!("marking challenge ready");
+        tls_chall.set_ready().await?;
+        Ok(())
+    }
 }
 
-/// A trait for something able to provision a challenge response with an external system
+/// A trait for something able to handle an authorization challenge
+///
+/// Usually this will be accomplished by provisioning a response with an external system,
+/// and then indicating the challenge is ready for validation by the ACME server.
 trait AuthorizationMethod {
-    /// Provision a challenge response for the given identifier, challenge, and key auth.
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a;
-
-    const PATH: &str;
-    const TYPE: ChallengeType;
+    /// Handle the challenge for this authorization method
+    fn handle_challenge<'a>(
+        authz: &'a mut AuthorizationHandle<'a>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> impl Future<Output = Result<(), Box<dyn StdError>>> + Send;
 }
 
 /// Wait for the server at the given address to be ready

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -762,13 +762,10 @@ impl AuthorizationMethod for Http01 {
     ) -> Result<(), Box<dyn StdError>> {
         let mut http_chall = authz.http01().expect("missing HTTP-01 challenge");
         let token = http_chall.token();
-        let key_auth = http_chall.key_authorization();
+        let auth_resp = http_chall.authorization();
+        let key_auth = auth_resp.key_authorization();
 
-        debug!(
-            token,
-            key_auth = key_auth.as_str(),
-            "provisioning HTTP-01 response",
-        );
+        debug!(token, key_auth, "provisioning HTTP-01 response",);
 
         #[derive(Serialize)]
         struct AddHttp01Request<'a> {
@@ -778,7 +775,7 @@ impl AuthorizationMethod for Http01 {
 
         let body = serde_json::to_vec(&AddHttp01Request {
             token,
-            content: key_auth.as_str(),
+            content: key_auth,
         })?;
         let url = format!("http://[::1]:{challtestsrv_port}/add-http01");
         client
@@ -806,15 +803,11 @@ impl AuthorizationMethod for Dns01 {
         challtestsrv_port: u16,
     ) -> Result<(), Box<dyn StdError>> {
         let mut dns_chall = authz.dns01().expect("missing DNS-01 challenge");
-        let key_auth = dns_chall.key_authorization().dns_value();
-        let identifier = dns_chall.identifier();
+        let auth_resp = dns_chall.authorization();
 
-        let Identifier::Dns(domain) = identifier.identifier else {
-            unreachable!("unsupported identifier {identifier:?}");
-        };
-
-        let host = format!("_acme-challenge.{domain}.");
-        debug!(host, key_auth, "provisioning DNS-01 response");
+        let host = auth_resp.host();
+        let rdata = auth_resp.rdata();
+        debug!(host, rdata, "provisioning DNS-01 response");
 
         #[derive(Serialize)]
         struct AddDns01Request {
@@ -824,7 +817,7 @@ impl AuthorizationMethod for Dns01 {
 
         let body = serde_json::to_vec(&AddDns01Request {
             host,
-            value: key_auth,
+            value: rdata.to_owned(),
         })?;
         let url = format!("http://[::1]:{challtestsrv_port}/set-txt");
         client
@@ -852,12 +845,15 @@ impl AuthorizationMethod for Alpn01 {
         challtestsrv_port: u16,
     ) -> Result<(), Box<dyn StdError>> {
         let mut tls_chall = authz.tls_alpn01().expect("missing TLS-ALPN-01 challenge");
-        let key_auth = tls_chall.key_authorization();
+        let auth_resp = tls_chall.authorization();
+        // Note: pebble-challtestsrv wants to hash the key auth itself, so we
+        // don't use `auth_resp.extension_value()` here.
+        let key_auth = auth_resp.key_authorization();
         let identifier = tls_chall.identifier();
 
         debug!(
             %identifier,
-            key_auth = key_auth.as_str(),
+            key_auth,
             "provisioning TLS-ALPN-01 response",
         );
 
@@ -869,9 +865,7 @@ impl AuthorizationMethod for Alpn01 {
 
         let body = serde_json::to_vec(&AddAlpn01Request {
             host: identifier.to_string(),
-            // Note: pebble-challtestsrv wants to hash the key auth itself, so we
-            // don't use key_auth.digest() here.
-            content: key_auth.as_str(),
+            content: key_auth,
         })?;
         let url = format!("http://[::1]:{}/add-tlsalpn01", challtestsrv_port);
         client


### PR DESCRIPTION
Continuation of https://github.com/djc/instant-acme/pull/265, opened as a new PR since I ended up going a bit of a different direction.

I ended up reworking the challenge state, challenge handle, and key authorization bits fairly substantially before landing the new `dns-persist-01` support. I think the key motivation of the design I landed on is that while it's convenient to try and abstract away authorization challenge response across multiple challenge types, in reality there are a lot of challenge type specific details one has to contend with even when using challenges that all derive the key auth from the token (e.g. the format of the key authorization: should it be the raw string? a SHA256 digest? the base64 of that digest?). Further, the new challenge types (dns-persist-01, device-attest-01) don't have as much in common with the "legacy" challenge types and so we should be using the type system more to differentiate the challenge contexts. This also lets us tighten up what challenges are used for which identifier types (e.g. to avoid a situation where you try to use device-attest-01 with a DNS identifier, or dns-01/dns-persist-01 with an IP address identifier).

Opened as a draft for now:

* I think we could probably get a bit more unit test coverage.
* I haven't tested dns-persist-01 support with any ACME CAs other than Pebble. It would be nice to verify it with Let's Encrypt staging before merge.
* I suspect there's some polish left to do for docs, type names, etc, based on review feedback.

Resolves https://github.com/djc/instant-acme/issues/263
