### PR TITLE
Per-type challenge state + handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ specification.
 * Supported extensions:
   * [ACME renewal information (ARI)]
   * [Profiles]
+  * [draft-ietf-acme-device-attest] (**Experimental**)
 * Support for external account binding, key rollover, and contact updates
 * Support for certificate revocation
 * Store/recover your account credentials by serializing/deserializing
@@ -28,6 +29,7 @@ specification.
 
 [ACME renewal information (ARI)]: https://www.rfc-editor.org/rfc/rfc9773.html
 [profiles]: https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/
+[draft-ietf-acme-device-attest]: https://datatracker.ietf.org/doc/draft-ietf-acme-device-attest/
 
 ## Cargo features
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ specification.
 * Supported extensions:
   * [ACME renewal information (ARI)]
   * [Profiles]
+  * [draft-acme-device-attest-08] (**Experimental**)
 * Support for external account binding, key rollover, and contact updates
 * Support for certificate revocation
 * Store/recover your account credentials by serializing/deserializing
@@ -28,6 +29,7 @@ specification.
 
 [ACME renewal information (ARI)]: https://www.rfc-editor.org/rfc/rfc9773.html
 [profiles]: https://datatracker.ietf.org/doc/draft-ietf-acme-profiles/
+[draft-acme-device-attest-08]: https://datatracker.ietf.org/doc/html/draft-acme-device-attest-08
 
 ## Cargo features
 

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -7,8 +7,8 @@ use clap::Parser;
 use tracing::info;
 
 use instant_acme::{
-    Account, AuthorizationStatus, ChallengeType, CryptoProvider, DefaultClient, Identifier,
-    LetsEncrypt, NewAccount, NewOrder, OrderStatus, RetryPolicy,
+    Account, AuthorizationStatus, CryptoProvider, DefaultClient, Identifier, LetsEncrypt,
+    NewAccount, NewOrder, OrderStatus, RetryPolicy,
 };
 
 #[tokio::main]
@@ -82,14 +82,14 @@ async fn main() -> anyhow::Result<()> {
         // pick something else to use here.
 
         let mut challenge = authz
-            .challenge(ChallengeType::Dns01)
+            .dns01()
             .ok_or_else(|| anyhow::anyhow!("no dns01 challenge found"))?;
 
         println!("Please set the following DNS record then press the Return key:");
         println!(
             "_acme-challenge.{} IN TXT {}",
             challenge.identifier(),
-            challenge.key_authorization()?.unwrap().dns_value()
+            challenge.key_authorization()?.dns_value()
         );
         io::stdin().read_line(&mut String::new())?;
 

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -86,10 +86,11 @@ async fn main() -> anyhow::Result<()> {
             .ok_or_else(|| anyhow::anyhow!("no dns01 challenge found"))?;
 
         println!("Please set the following DNS record then press the Return key:");
+        let authz_response = challenge.authorization()?;
         println!(
-            "_acme-challenge.{} IN TXT {}",
-            challenge.identifier(),
-            challenge.key_authorization()?.dns_value()
+            "{} IN TXT {}",
+            authz_response.host(),
+            authz_response.rdata()
         );
         io::stdin().read_line(&mut String::new())?;
 

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -89,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
         println!(
             "_acme-challenge.{} IN TXT {}",
             challenge.identifier(),
-            challenge.key_authorization()?.dns_value()
+            challenge.key_authorization()?.unwrap().dns_value()
         );
         io::stdin().read_line(&mut String::new())?;
 

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -86,11 +86,8 @@ async fn main() -> anyhow::Result<()> {
             .ok_or_else(|| anyhow::anyhow!("no dns01 challenge found"))?;
 
         println!("Please set the following DNS record then press the Return key:");
-        println!(
-            "_acme-challenge.{} IN TXT {}",
-            challenge.identifier(),
-            challenge.key_authorization()?.dns_value()
-        );
+        let response = challenge.response();
+        println!("{} IN TXT {}", response.host(), response.rdata());
         io::stdin().read_line(&mut String::new())?;
 
         challenge.set_ready().await?;

--- a/src/account.rs
+++ b/src/account.rs
@@ -324,8 +324,8 @@ impl Account {
     }
 
     /// Get the [RFC 7638](https://www.rfc-editor.org/rfc/rfc7638) account key thumbprint
-    pub fn key_thumbprint(&self) -> Result<String, Error> {
-        Ok(BASE64_URL_SAFE_NO_PAD.encode(self.inner.key.thumb_sha256()?))
+    pub fn key_thumbprint(&self) -> &str {
+        self.inner.key.thumbprint()
     }
 }
 
@@ -569,9 +569,24 @@ impl AccountBuilder {
 pub struct Key {
     pub(crate) inner: Box<dyn SigningKey>,
     pub(crate) provider: &'static CryptoProvider,
+    thumbprint: String,
 }
 
 impl Key {
+    fn new(inner: Box<dyn SigningKey>, provider: &'static CryptoProvider) -> Result<Self, Error> {
+        let thumbprint = BASE64_URL_SAFE_NO_PAD.encode(
+            inner
+                .as_jwk()
+                .thumb_sha256(provider.sha256)
+                .map_err(Error::Json)?,
+        );
+        Ok(Self {
+            inner,
+            provider,
+            thumbprint,
+        })
+    }
+
     /// Generate a new key pair using the given [`CryptoProvider`]
     ///
     /// The key type depends on the provider.
@@ -579,20 +594,11 @@ impl Key {
         provider: &'static CryptoProvider,
     ) -> Result<(Self, PrivatePkcs8KeyDer<'static>), Error> {
         let (key, pkcs8) = provider.key_provider.generate_key()?;
-        Ok((
-            Self {
-                inner: key,
-                provider,
-            },
-            pkcs8,
-        ))
+        Ok((Self::new(key, provider)?, pkcs8))
     }
 
-    pub(crate) fn thumb_sha256(&self) -> Result<[u8; 32], Error> {
-        self.inner
-            .as_jwk()
-            .thumb_sha256(self.provider.sha256)
-            .map_err(Error::Json)
+    pub(crate) fn thumbprint(&self) -> &str {
+        &self.thumbprint
     }
 
     /// Create a key from the given PKCS#8 DER-encoded private key using the given
@@ -603,10 +609,7 @@ impl Key {
     ) -> Result<Self, Error> {
         let owned = PrivatePkcs8KeyDer::from(pkcs8_der.secret_pkcs8_der().to_vec());
         let key = provider.key_provider.load_key(owned)?;
-        Ok(Self {
-            inner: key,
-            provider,
-        })
+        Self::new(key, provider)
     }
 }
 

--- a/src/challenges.rs
+++ b/src/challenges.rs
@@ -11,19 +11,66 @@ use crate::types::Problem;
 /// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.5>
 #[derive(Debug, Deserialize)]
 pub struct Challenge {
-    /// Type of challenge
-    pub r#type: ChallengeType,
     /// Challenge identifier
     pub url: String,
-    /// Token for this challenge
-    ///
-    /// Unknown `ChallengeType` instances may omit this field, leaving it empty.
-    #[serde(default)]
-    pub token: String,
+    /// Challenge type specific state
+    #[serde(flatten)]
+    pub state: ChallengeState,
     /// Current status
     pub status: ChallengeStatus,
     /// Potential error state
     pub error: Option<Problem>,
+}
+
+/// Challenge type specific state
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(tag = "type")]
+#[non_exhaustive]
+pub enum ChallengeState {
+    /// State for an RFC 8555 HTTP-01 challenge
+    #[serde(rename = "http-01")]
+    Http01(http01::Challenge),
+    /// State for an RFC 8555 DNS-01 challenge
+    #[serde(rename = "dns-01")]
+    Dns01(dns01::Challenge),
+    /// State for an RFC 8737 TLS-ALPN-01 challenge
+    #[serde(rename = "tls-alpn-01")]
+    TlsAlpn01(tls_alpn01::Challenge),
+    /// State for a draft-acme-device-attest-08 challenge
+    ///
+    /// Note: Device attestation support is experimental
+    #[serde(rename = "device-attest-01")]
+    DeviceAttest01(device_attest01::Challenge),
+    /// An unknown challenge type
+    #[serde(other)]
+    Unknown,
+}
+
+impl ChallengeState {
+    /// Get the token associated with this challenge (if applicable)
+    ///
+    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a token. Other challenge types
+    /// do not rely on RFC 8555 key authorizations and will return `None`, expecting the
+    /// challenge to be satisfied with another method specific to its type.
+    pub fn token(&self) -> Option<&str> {
+        Some(match self {
+            Self::Http01(http01::Challenge { token })
+            | Self::Dns01(dns01::Challenge { token })
+            | Self::TlsAlpn01(tls_alpn01::Challenge { token }) => token,
+            Self::DeviceAttest01(_) | Self::Unknown => return None,
+        })
+    }
+
+    /// Get the challenge type associated with this challenge state
+    pub fn r#type(&self) -> ChallengeType {
+        match self {
+            Self::Http01(_) => ChallengeType::Http01,
+            Self::Dns01(_) => ChallengeType::Dns01,
+            Self::TlsAlpn01(_) => ChallengeType::TlsAlpn01,
+            Self::DeviceAttest01(_) => ChallengeType::DeviceAttest01,
+            Self::Unknown => ChallengeType::Unknown,
+        }
+    }
 }
 
 /// The challenge type
@@ -41,7 +88,7 @@ pub enum ChallengeType {
     #[serde(rename = "device-attest-01")]
     DeviceAttest01,
     #[serde(untagged)]
-    Unknown(String),
+    Unknown,
 }
 
 /// Status of an ACME [Challenge]
@@ -53,6 +100,71 @@ pub enum ChallengeStatus {
     Processing,
     Valid,
     Invalid,
+}
+
+pub mod http01 {
+    //! Support for RFC 8555 http-01 challenges
+    //!
+    //! See <https://www.rfc-editor.org/rfc/rfc8555#section-8.3>
+
+    use serde::Deserialize;
+
+    /// Challenge state for an http-01 challenge
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+    #[non_exhaustive]
+    pub struct Challenge {
+        /// A token for constructing a key authorization to complete this challenge
+        pub token: String,
+    }
+}
+
+pub mod dns01 {
+    //! Support for RFC 8555 dns-01 challenges
+    //!
+    //! See <https://www.rfc-editor.org/rfc/rfc8555#section-8.4>
+
+    use serde::Deserialize;
+
+    /// Challenge state for a dns-01 challenge
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+    #[non_exhaustive]
+    pub struct Challenge {
+        /// A token for constructing a key authorization to complete this challenge
+        pub token: String,
+    }
+}
+
+pub mod tls_alpn01 {
+    //! Support for RFC 8737 tls-alpn-01 challenges
+    //!
+    //! See <https://www.rfc-editor.org/rfc/rfc8737#section-3>
+
+    use serde::Deserialize;
+
+    /// Challenge state for a tls-alpn-01 challenge
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+    #[non_exhaustive]
+    pub struct Challenge {
+        /// A token for constructing a key authorization to complete this challenge
+        pub token: String,
+    }
+}
+
+pub mod device_attest01 {
+    //! Support for draft-ietf-acme-device-attest device-attest-01 challenges
+    //!
+    //! See <https://datatracker.ietf.org/doc/draft-ietf-acme-device-attest/>
+    //!
+    //! Note: device attestation support is experimental.
+
+    use serde::Deserialize;
+
+    /// Challenge state for a device-attest-01 challenge
+    ///
+    /// device-attest-01 challenges carry no additional type specific state.
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+    #[non_exhaustive]
+    pub struct Challenge {}
 }
 
 /// Attestation payload used for device-attest-01
@@ -78,9 +190,12 @@ mod tests {
         }"#;
 
         let obj = serde_json::from_str::<Challenge>(CHALLENGE).unwrap();
-        assert_eq!(obj.r#type, ChallengeType::Dns01);
+        assert_eq!(obj.state.r#type(), ChallengeType::Dns01);
         assert_eq!(obj.url, "https://example.com/acme/chall/Rg5dV14Gh1Q");
         assert_eq!(obj.status, ChallengeStatus::Pending);
-        assert_eq!(obj.token, "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA");
+        assert_eq!(
+            obj.state.token(),
+            Some("evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA")
+        );
     }
 }

--- a/src/challenges.rs
+++ b/src/challenges.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
-use crate::account::AccountInner;
+use crate::account::{AccountInner, Key};
 use crate::nonce_from_response;
 use crate::types::{AuthorizationState, AuthorizedIdentifier, Empty, Error, Problem};
 
@@ -138,7 +138,6 @@ impl ChallengeHandleState<'_> {
             None => Ok(response.status),
         }
     }
-
 }
 
 /// A challenge state type corresponding to one [`ChallengeState`] variant
@@ -150,6 +149,30 @@ pub(crate) trait ChallengeVariant: Sized {
     fn from_state(state: &ChallengeState) -> Option<&Self>;
 }
 
+#[derive(Debug)]
+struct KeyAuthorization {
+    // The token is stored as the key authorization's prefix; retaining its length lets
+    // token() borrow that prefix without allocating a second String.
+    token_len: usize,
+    value: String,
+    digest: [u8; 32],
+}
+
+impl KeyAuthorization {
+    fn new(token: &str, key: &Key) -> Self {
+        let value = format!("{token}.{}", key.thumbprint());
+        Self {
+            digest: key.provider.sha256.hash(value.as_bytes()),
+            token_len: token.len(),
+            value,
+        }
+    }
+
+    fn token(&self) -> &str {
+        &self.value[..self.token_len]
+    }
+}
+
 pub mod http01 {
     //! Support for RFC 8555 http-01 challenges
     //!
@@ -157,8 +180,8 @@ pub mod http01 {
 
     use serde::Deserialize;
 
-    use super::{ChallengeHandle, ChallengeState, ChallengeVariant};
-    use crate::{Error, KeyAuthorization};
+    use super::{ChallengeHandle, ChallengeState, ChallengeVariant, KeyAuthorization};
+    use crate::types::Error;
 
     /// Challenge state for an http-01 challenge
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -188,9 +211,37 @@ pub mod http01 {
             &self.challenge.token
         }
 
-        /// Create a [`KeyAuthorization`] for this challenge
-        pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
-            KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+        /// Create a [`Response`] for this challenge
+        pub fn response(&self) -> Response {
+            Response::new(&self.challenge.token, &self.state.account.key)
+        }
+    }
+
+    /// Challenge response data for an http-01 challenge
+    #[must_use = "the response data must be provisioned before marking the challenge ready"]
+    #[derive(Debug)]
+    pub struct Response {
+        key_authorization: KeyAuthorization,
+    }
+
+    impl Response {
+        fn new(token: &str, key: &super::Key) -> Self {
+            Self {
+                key_authorization: KeyAuthorization::new(token, key),
+            }
+        }
+
+        /// The challenge token for this challenge response.
+        pub fn token(&self) -> &str {
+            self.key_authorization.token()
+        }
+
+        /// The key authorization content that should be placed in the challenge response file.
+        ///
+        /// The file should be provisioned at `/.well-known/acme-challenge/<token>` in your
+        /// webserver's web root.
+        pub fn key_authorization(&self) -> &str {
+            &self.key_authorization.value
         }
     }
 
@@ -203,10 +254,12 @@ pub mod dns01 {
     //!
     //! See <https://www.rfc-editor.org/rfc/rfc8555#section-8.4>
 
+    use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine};
     use serde::Deserialize;
 
-    use super::{ChallengeHandle, ChallengeState, ChallengeVariant};
-    use crate::{Error, KeyAuthorization};
+    use super::{ChallengeHandle, ChallengeState, ChallengeVariant, KeyAuthorization};
+    use crate::account::Key;
+    use crate::types::{Error, Identifier};
 
     /// Challenge state for a dns-01 challenge
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -236,9 +289,50 @@ pub mod dns01 {
             &self.challenge.token
         }
 
-        /// Create a [`KeyAuthorization`] for this challenge
-        pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
-            KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+        /// Create a [`Response`] for this challenge
+        pub fn response(&self) -> Response {
+            Response::new(
+                self.state.identifier.identifier,
+                &self.challenge.token,
+                &self.state.account.key,
+            )
+        }
+    }
+
+    /// Challenge response data for a dns-01 challenge
+    #[must_use = "the response data must be provisioned before marking the challenge ready"]
+    #[derive(Debug)]
+    pub struct Response {
+        host: String,
+        rdata: String,
+    }
+
+    impl Response {
+        fn new(identifier: &Identifier, token: &str, key: &Key) -> Self {
+            let Identifier::Dns(domain) = identifier else {
+                unreachable!("DNS-01 only supports domain identifiers");
+            };
+
+            let key_authorization = KeyAuthorization::new(token, key);
+
+            Self {
+                host: format!("_acme-challenge.{domain}."),
+                rdata: BASE64_URL_SAFE_NO_PAD.encode(key_authorization.digest),
+            }
+        }
+
+        /// Fully qualified hostname for the challenge response TXT record to be provisioned
+        ///
+        /// Includes a trailing dot.
+        pub fn host(&self) -> &str {
+            &self.host
+        }
+
+        /// The TXT record RDATA to provision for [`Self::host()`]
+        ///
+        /// This is the base64-encoded SHA256 digest of the challenge key authorization.
+        pub fn rdata(&self) -> &str {
+            &self.rdata
         }
     }
 
@@ -253,8 +347,8 @@ pub mod tls_alpn01 {
 
     use serde::Deserialize;
 
-    use super::{ChallengeHandle, ChallengeState, ChallengeVariant};
-    use crate::{Error, KeyAuthorization};
+    use super::{ChallengeHandle, ChallengeState, ChallengeVariant, KeyAuthorization};
+    use crate::types::Error;
 
     /// Challenge state for a tls-alpn-01 challenge
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -284,9 +378,43 @@ pub mod tls_alpn01 {
             &self.challenge.token
         }
 
-        /// Create a [`KeyAuthorization`] for this challenge
-        pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
-            KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+        /// Create a [`Response`] for this challenge
+        pub fn response(&self) -> Response {
+            Response::new(&self.challenge.token, &self.state.account.key)
+        }
+    }
+
+    /// Challenge response data for a tls-alpn-01 challenge
+    #[must_use = "the response data must be provisioned before marking the challenge ready"]
+    #[derive(Debug)]
+    pub struct Response {
+        key_authorization: KeyAuthorization,
+    }
+
+    impl Response {
+        fn new(token: &str, key: &super::Key) -> Self {
+            Self {
+                key_authorization: KeyAuthorization::new(token, key),
+            }
+        }
+
+        /// The unhashed key authorization string
+        ///
+        /// Typically, you would prefer using [`Self::extension_value`] to construct
+        /// a DER encoded id-pe-acmeIdentifier extension.
+        ///
+        /// This API may be useful when using a higher-level TLS-ALPN-01 certificate generation
+        /// API that expects the RFC-8555 §8.1 key authorization string as input.
+        pub fn key_authorization(&self) -> &str {
+            &self.key_authorization.value
+        }
+
+        /// The SHA-256 digest of the RFC-8555 §8.1 key authorization string
+        ///
+        /// This can be used to construct a DER encoded id-pe-acmeIdentifier extension
+        /// for embedding in a provisioned TLS-ALPN-01 challenge response certificate.
+        pub fn extension_value(&self) -> &[u8; 32] {
+            &self.key_authorization.digest
         }
     }
 

--- a/src/challenges.rs
+++ b/src/challenges.rs
@@ -1,0 +1,86 @@
+//! ACME challenges and challenge type specific handling
+
+use std::borrow::Cow;
+
+use serde::Deserialize;
+
+use crate::types::Problem;
+
+/// An ACME challenge as described in RFC 8555 (section 7.1.5)
+///
+/// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.5>
+#[derive(Debug, Deserialize)]
+pub struct Challenge {
+    /// Type of challenge
+    pub r#type: ChallengeType,
+    /// Challenge identifier
+    pub url: String,
+    /// Token for this challenge
+    ///
+    /// Unknown `ChallengeType` instances may omit this field, leaving it empty.
+    #[serde(default)]
+    pub token: String,
+    /// Current status
+    pub status: ChallengeStatus,
+    /// Potential error state
+    pub error: Option<Problem>,
+}
+
+/// The challenge type
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub enum ChallengeType {
+    #[serde(rename = "http-01")]
+    Http01,
+    #[serde(rename = "dns-01")]
+    Dns01,
+    #[serde(rename = "tls-alpn-01")]
+    TlsAlpn01,
+    /// Note: Device attestation support is experimental
+    #[serde(rename = "device-attest-01")]
+    DeviceAttest01,
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+/// Status of an ACME [Challenge]
+#[allow(missing_docs)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum ChallengeStatus {
+    Pending,
+    Processing,
+    Valid,
+    Invalid,
+}
+
+/// Attestation payload used for device-attest-01
+///
+/// See <https://datatracker.ietf.org/doc/draft-acme-device-attest/> for details.
+pub struct DeviceAttestation<'a> {
+    /// CBOR encoded attestation payload
+    pub att_obj: Cow<'a, [u8]>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // https://datatracker.ietf.org/doc/html/rfc8555#section-8.4
+    #[test]
+    fn challenge() {
+        const CHALLENGE: &str = r#"{
+          "type": "dns-01",
+          "url": "https://example.com/acme/chall/Rg5dV14Gh1Q",
+          "status": "pending",
+          "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA"
+        }"#;
+
+        let obj = serde_json::from_str::<Challenge>(CHALLENGE).unwrap();
+        assert_eq!(obj.r#type, ChallengeType::Dns01);
+        assert_eq!(obj.url, "https://example.com/acme/chall/Rg5dV14Gh1Q");
+        assert_eq!(obj.status, ChallengeStatus::Pending);
+        assert_eq!(obj.token, "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA");
+    }
+}

--- a/src/challenges.rs
+++ b/src/challenges.rs
@@ -2,9 +2,11 @@
 
 use std::borrow::Cow;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-use crate::types::Problem;
+use crate::account::AccountInner;
+use crate::nonce_from_response;
+use crate::types::{AuthorizationState, AuthorizedIdentifier, Empty, Error, Problem};
 
 /// An ACME challenge as described in RFC 8555 (section 7.1.5)
 ///
@@ -47,20 +49,6 @@ pub enum ChallengeState {
 }
 
 impl ChallengeState {
-    /// Get the token associated with this challenge (if applicable)
-    ///
-    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a token. Other challenge types
-    /// do not rely on RFC 8555 key authorizations and will return `None`, expecting the
-    /// challenge to be satisfied with another method specific to its type.
-    pub fn token(&self) -> Option<&str> {
-        Some(match self {
-            Self::Http01(http01::Challenge { token })
-            | Self::Dns01(dns01::Challenge { token })
-            | Self::TlsAlpn01(tls_alpn01::Challenge { token }) => token,
-            Self::DeviceAttest01(_) | Self::Unknown => return None,
-        })
-    }
-
     /// Get the challenge type associated with this challenge state
     pub fn r#type(&self) -> ChallengeType {
         match self {
@@ -102,12 +90,106 @@ pub enum ChallengeStatus {
     Invalid,
 }
 
+/// A handle for interacting with a challenge of a specific type
+///
+/// The `T` type parameter is the challenge type specific state type (e.g.
+/// [`http01::Challenge`]) and determines which operations are available.
+/// Obtain a handle from the accessor for the challenge type on
+/// [`AuthorizationHandle`][crate::AuthorizationHandle] (e.g.
+/// [`AuthorizationHandle::http01()`][crate::AuthorizationHandle::http01()]).
+pub struct ChallengeHandle<'a, T> {
+    state: ChallengeHandleState<'a>,
+    challenge: &'a T,
+}
+
+impl<'a, T> ChallengeHandle<'a, T> {
+    pub(crate) fn new(
+        authz: &'a AuthorizationState,
+        nonce: &'a mut Option<String>,
+        account: &'a AccountInner,
+    ) -> Option<Self>
+    where
+        T: ChallengeVariant,
+    {
+        let (challenge, data) = authz
+            .challenges
+            .iter()
+            .find_map(|c| Some((c, T::from_state(&c.state)?)))?;
+        Some(Self {
+            state: ChallengeHandleState {
+                identifier: authz.identifier(),
+                challenge,
+                nonce,
+                account,
+            },
+            challenge: data,
+        })
+    }
+}
+
+impl<T> ChallengeHandle<'_, T> {
+    /// The underlying ACME challenge
+    pub fn challenge(&self) -> &Challenge {
+        self.state.challenge
+    }
+
+    /// The identifier for this challenge's authorization
+    pub fn identifier(&self) -> &AuthorizedIdentifier<'_> {
+        &self.state.identifier
+    }
+}
+
+/// Shared state common to all challenge handles
+struct ChallengeHandleState<'a> {
+    identifier: AuthorizedIdentifier<'a>,
+    challenge: &'a Challenge,
+    nonce: &'a mut Option<String>,
+    account: &'a AccountInner,
+}
+
+impl ChallengeHandleState<'_> {
+    /// Notify the server that the given challenge is ready to be completed
+    ///
+    /// Traditional token-based challenges are acknowledged with an empty object body.
+    async fn set_ready(&mut self) -> Result<(), Error> {
+        self.respond(&Empty {}).await.map(drop)
+    }
+
+    /// Respond to the challenge with a type-specific payload
+    async fn respond(&mut self, payload: &impl Serialize) -> Result<ChallengeStatus, Error> {
+        let rsp = self
+            .account
+            .post(Some(payload), self.nonce.take(), &self.challenge.url)
+            .await?;
+
+        *self.nonce = nonce_from_response(&rsp);
+        let response = Problem::check::<Challenge>(rsp).await?;
+        match response.error {
+            Some(details) => Err(Error::Api(details)),
+            None => Ok(response.status),
+        }
+    }
+
+}
+
+/// A challenge state type corresponding to one [`ChallengeState`] variant
+///
+/// Implemented by the challenge state types in the per-challenge type submodules
+/// (e.g. [`http01::Challenge`]).
+pub(crate) trait ChallengeVariant: Sized {
+    /// Get a reference to this state type's data from `state`, if the type matches
+    fn from_state(state: &ChallengeState) -> Option<&Self>;
+}
+
 pub mod http01 {
     //! Support for RFC 8555 http-01 challenges
     //!
     //! See <https://www.rfc-editor.org/rfc/rfc8555#section-8.3>
 
     use serde::Deserialize;
+
+    use super::{ChallengeHandle, ChallengeState, ChallengeVariant};
+    use crate::{Error, KeyAuthorization};
 
     /// Challenge state for an http-01 challenge
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -116,6 +198,35 @@ pub mod http01 {
         /// A token for constructing a key authorization to complete this challenge
         pub token: String,
     }
+
+    impl ChallengeVariant for Challenge {
+        fn from_state(state: &ChallengeState) -> Option<&Self> {
+            match state {
+                ChallengeState::Http01(data) => Some(data),
+                _ => None,
+            }
+        }
+    }
+
+    impl ChallengeHandle<'_, Challenge> {
+        /// Notify the server that the challenge is ready to be completed
+        pub async fn set_ready(&mut self) -> Result<(), Error> {
+            self.state.set_ready().await
+        }
+
+        /// The token for this challenge
+        pub fn token(&self) -> &str {
+            &self.challenge.token
+        }
+
+        /// Create a [`KeyAuthorization`] for this challenge
+        pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
+            KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+        }
+    }
+
+    /// A handle for interacting with an http-01 challenge
+    pub type Handle<'a> = ChallengeHandle<'a, Challenge>;
 }
 
 pub mod dns01 {
@@ -125,6 +236,9 @@ pub mod dns01 {
 
     use serde::Deserialize;
 
+    use super::{ChallengeHandle, ChallengeState, ChallengeVariant};
+    use crate::{Error, KeyAuthorization};
+
     /// Challenge state for a dns-01 challenge
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
     #[non_exhaustive]
@@ -132,6 +246,35 @@ pub mod dns01 {
         /// A token for constructing a key authorization to complete this challenge
         pub token: String,
     }
+
+    impl ChallengeVariant for Challenge {
+        fn from_state(state: &ChallengeState) -> Option<&Self> {
+            match state {
+                ChallengeState::Dns01(data) => Some(data),
+                _ => None,
+            }
+        }
+    }
+
+    impl ChallengeHandle<'_, Challenge> {
+        /// Notify the server that the challenge is ready to be completed
+        pub async fn set_ready(&mut self) -> Result<(), Error> {
+            self.state.set_ready().await
+        }
+
+        /// The token for this challenge
+        pub fn token(&self) -> &str {
+            &self.challenge.token
+        }
+
+        /// Create a [`KeyAuthorization`] for this challenge
+        pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
+            KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+        }
+    }
+
+    /// A handle for interacting with a dns-01 challenge
+    pub type Handle<'a> = ChallengeHandle<'a, Challenge>;
 }
 
 pub mod tls_alpn01 {
@@ -141,6 +284,9 @@ pub mod tls_alpn01 {
 
     use serde::Deserialize;
 
+    use super::{ChallengeHandle, ChallengeState, ChallengeVariant};
+    use crate::{Error, KeyAuthorization};
+
     /// Challenge state for a tls-alpn-01 challenge
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
     #[non_exhaustive]
@@ -148,6 +294,35 @@ pub mod tls_alpn01 {
         /// A token for constructing a key authorization to complete this challenge
         pub token: String,
     }
+
+    impl ChallengeVariant for Challenge {
+        fn from_state(state: &ChallengeState) -> Option<&Self> {
+            match state {
+                ChallengeState::TlsAlpn01(data) => Some(data),
+                _ => None,
+            }
+        }
+    }
+
+    impl ChallengeHandle<'_, Challenge> {
+        /// Notify the server that the challenge is ready to be completed
+        pub async fn set_ready(&mut self) -> Result<(), Error> {
+            self.state.set_ready().await
+        }
+
+        /// The token for this challenge
+        pub fn token(&self) -> &str {
+            &self.challenge.token
+        }
+
+        /// Create a [`KeyAuthorization`] for this challenge
+        pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
+            KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+        }
+    }
+
+    /// A handle for interacting with a tls-alpn-01 challenge
+    pub type Handle<'a> = ChallengeHandle<'a, Challenge>;
 }
 
 pub mod device_attest01 {
@@ -157,7 +332,15 @@ pub mod device_attest01 {
     //!
     //! Note: device attestation support is experimental.
 
-    use serde::Deserialize;
+    use std::borrow::Cow;
+
+    use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine};
+    use serde::{Deserialize, Serialize};
+
+    use super::{
+        ChallengeHandle, ChallengeState, ChallengeStatus, ChallengeVariant, DeviceAttestation,
+    };
+    use crate::types::Error;
 
     /// Challenge state for a device-attest-01 challenge
     ///
@@ -165,6 +348,43 @@ pub mod device_attest01 {
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
     #[non_exhaustive]
     pub struct Challenge {}
+
+    impl ChallengeVariant for Challenge {
+        fn from_state(state: &ChallengeState) -> Option<&Self> {
+            match state {
+                ChallengeState::DeviceAttest01(data) => Some(data),
+                _ => None,
+            }
+        }
+    }
+
+    impl ChallengeHandle<'_, Challenge> {
+        /// Notify the server that the challenge is ready by sending a device attestation
+        ///
+        /// See <https://datatracker.ietf.org/doc/draft-ietf-acme-device-attest/> for details.
+        ///
+        /// `payload` is the device attestation object. Provide the attestation
+        /// object as a raw blob; base64 encoding is done by this function.
+        pub async fn send_attestation(
+            &mut self,
+            payload: &DeviceAttestation<'_>,
+        ) -> Result<ChallengeStatus, Error> {
+            #[derive(Serialize)]
+            #[serde(rename_all = "camelCase")]
+            struct DeviceAttestationBase64<'a> {
+                att_obj: Cow<'a, str>,
+            }
+
+            let payload = DeviceAttestationBase64 {
+                att_obj: Cow::Owned(BASE64_URL_SAFE_NO_PAD.encode(&payload.att_obj)),
+            };
+
+            self.state.respond(&payload).await
+        }
+    }
+
+    /// A handle for interacting with a device-attest-01 challenge
+    pub type Handle<'a> = ChallengeHandle<'a, Challenge>;
 }
 
 /// Attestation payload used for device-attest-01
@@ -193,9 +413,13 @@ mod tests {
         assert_eq!(obj.state.r#type(), ChallengeType::Dns01);
         assert_eq!(obj.url, "https://example.com/acme/chall/Rg5dV14Gh1Q");
         assert_eq!(obj.status, ChallengeStatus::Pending);
+
+        let ChallengeState::Dns01(chall_state) = obj.state else {
+            panic!("wrong challenge state type");
+        };
         assert_eq!(
-            obj.state.token(),
-            Some("evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA")
+            chall_state.token,
+            "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA",
         );
     }
 }

--- a/src/challenges.rs
+++ b/src/challenges.rs
@@ -48,37 +48,6 @@ pub enum ChallengeState {
     Unknown,
 }
 
-impl ChallengeState {
-    /// Get the challenge type associated with this challenge state
-    pub fn r#type(&self) -> ChallengeType {
-        match self {
-            Self::Http01(_) => ChallengeType::Http01,
-            Self::Dns01(_) => ChallengeType::Dns01,
-            Self::TlsAlpn01(_) => ChallengeType::TlsAlpn01,
-            Self::DeviceAttest01(_) => ChallengeType::DeviceAttest01,
-            Self::Unknown => ChallengeType::Unknown,
-        }
-    }
-}
-
-/// The challenge type
-#[allow(missing_docs)]
-#[non_exhaustive]
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
-pub enum ChallengeType {
-    #[serde(rename = "http-01")]
-    Http01,
-    #[serde(rename = "dns-01")]
-    Dns01,
-    #[serde(rename = "tls-alpn-01")]
-    TlsAlpn01,
-    /// Note: Device attestation support is experimental
-    #[serde(rename = "device-attest-01")]
-    DeviceAttest01,
-    #[serde(untagged)]
-    Unknown,
-}
-
 /// Status of an ACME [Challenge]
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
@@ -410,7 +379,6 @@ mod tests {
         }"#;
 
         let obj = serde_json::from_str::<Challenge>(CHALLENGE).unwrap();
-        assert_eq!(obj.state.r#type(), ChallengeType::Dns01);
         assert_eq!(obj.url, "https://example.com/acme/chall/Rg5dV14Gh1Q");
         assert_eq!(obj.status, ChallengeStatus::Pending);
 

--- a/src/challenges.rs
+++ b/src/challenges.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::account::{AccountInner, Key};
 use crate::nonce_from_response;
-use crate::types::{AuthorizationState, AuthorizedIdentifier, Empty, Error, Problem};
+use crate::types::{AuthorizationState, AuthorizedIdentifier, Empty, Error, Identifier, Problem};
 
 /// An ACME challenge as described in RFC 8555 (section 7.1.5)
 ///
@@ -80,6 +80,10 @@ impl<'a, T> ChallengeHandle<'a, T> {
     where
         T: ChallengeVariant,
     {
+        if !T::supports_identifier(authz.identifier().identifier) {
+            return None;
+        }
+
         let (challenge, data) = authz
             .challenges
             .iter()
@@ -147,6 +151,9 @@ impl ChallengeHandleState<'_> {
 pub(crate) trait ChallengeVariant: Sized {
     /// Get a reference to this state type's data from `state`, if the type matches
     fn from_state(state: &ChallengeState) -> Option<&Self>;
+
+    /// Whether this challenge type supports authorizations for `identifier`
+    fn supports_identifier(identifier: &Identifier) -> bool;
 }
 
 #[derive(Debug)]
@@ -181,7 +188,7 @@ pub mod http01 {
     use serde::Deserialize;
 
     use super::{ChallengeHandle, ChallengeState, ChallengeVariant, KeyAuthorization};
-    use crate::types::Error;
+    use crate::types::{Error, Identifier};
 
     /// Challenge state for an http-01 challenge
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -197,6 +204,12 @@ pub mod http01 {
                 ChallengeState::Http01(data) => Some(data),
                 _ => None,
             }
+        }
+
+        fn supports_identifier(identifier: &Identifier) -> bool {
+            // https://www.rfc-editor.org/info/rfc8555/#section-9.7.8
+            // https://www.rfc-editor.org/info/rfc8738/#section-8.2
+            matches!(identifier, Identifier::Dns(_) | Identifier::Ip(_))
         }
     }
 
@@ -276,6 +289,12 @@ pub mod dns01 {
                 _ => None,
             }
         }
+
+        fn supports_identifier(identifier: &Identifier) -> bool {
+            // https://www.rfc-editor.org/info/rfc8555/#section-9.7.8
+            // https://www.rfc-editor.org/rfc/rfc8738#section-7
+            matches!(identifier, Identifier::Dns(_))
+        }
     }
 
     impl ChallengeHandle<'_, Challenge> {
@@ -348,7 +367,7 @@ pub mod tls_alpn01 {
     use serde::Deserialize;
 
     use super::{ChallengeHandle, ChallengeState, ChallengeVariant, KeyAuthorization};
-    use crate::types::Error;
+    use crate::types::{Error, Identifier};
 
     /// Challenge state for a tls-alpn-01 challenge
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -364,6 +383,12 @@ pub mod tls_alpn01 {
                 ChallengeState::TlsAlpn01(data) => Some(data),
                 _ => None,
             }
+        }
+
+        fn supports_identifier(identifier: &Identifier) -> bool {
+            // https://www.rfc-editor.org/info/rfc8737/#section-6.3
+            // https://www.rfc-editor.org/info/rfc8738/#section-8.2
+            matches!(identifier, Identifier::Dns(_) | Identifier::Ip(_))
         }
     }
 
@@ -437,7 +462,7 @@ pub mod device_attest01 {
     use super::{
         ChallengeHandle, ChallengeState, ChallengeStatus, ChallengeVariant, DeviceAttestation,
     };
-    use crate::types::Error;
+    use crate::types::{Error, Identifier};
 
     /// Challenge state for a device-attest-01 challenge
     ///
@@ -452,6 +477,14 @@ pub mod device_attest01 {
                 ChallengeState::DeviceAttest01(data) => Some(data),
                 _ => None,
             }
+        }
+
+        fn supports_identifier(identifier: &Identifier) -> bool {
+            // https://datatracker.ietf.org/doc/html/draft-acme-device-attest-08#section-7.2
+            matches!(
+                identifier,
+                Identifier::PermanentIdentifier(_) | Identifier::HardwareModule(_)
+            )
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,17 +52,16 @@ pub use crypto::{
 
 mod order;
 pub use order::{
-    AuthorizationHandle, Authorizations, ChallengeHandle, Identifiers, KeyAuthorization, Order,
-    RetryPolicy,
+    AuthorizationHandle, Authorizations, ChallengeHandle, Identifiers, Order, RetryPolicy,
 };
 
 mod types;
 pub use types::{
     AccountCredentials, Authorization, AuthorizationState, AuthorizationStatus,
     AuthorizedIdentifier, CertificateIdentifier, Challenge, ChallengeStatus, ChallengeType,
-    DeviceAttestation, EcCurve, Error, Identifier, Jwk, JwkThumbFields, LetsEncrypt, NewAccount,
-    NewOrder, OctetKeyCurve, OrderState, OrderStatus, Problem, ProfileMeta, RevocationReason,
-    RevocationRequest, SigningAlgorithm, Subproblem, ZeroSsl,
+    DeviceAttestation, EcCurve, Error, Identifier, Jwk, JwkThumbFields, KeyAuthorization,
+    LetsEncrypt, NewAccount, NewOrder, OctetKeyCurve, OrderState, OrderStatus, Problem,
+    ProfileMeta, RevocationReason, RevocationRequest, SigningAlgorithm, Subproblem, ZeroSsl,
 };
 use types::{Directory, JoseJson, Signer};
 #[cfg(feature = "time")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,11 @@ pub use order::{
 mod types;
 pub use types::{
     AccountCredentials, Authorization, AuthorizationState, AuthorizationStatus,
-    AuthorizedIdentifier, CertificateIdentifier, Challenge, ChallengeStatus, ChallengeType,
-    DeviceAttestation, EcCurve, Error, Identifier, Jwk, JwkThumbFields, KeyAuthorization,
-    LetsEncrypt, NewAccount, NewOrder, OctetKeyCurve, OrderState, OrderStatus, Problem,
-    ProfileMeta, RevocationReason, RevocationRequest, SigningAlgorithm, Subproblem, ZeroSsl,
+    AuthorizedIdentifier, CertificateIdentifier, Challenge, ChallengeState, ChallengeStatus,
+    ChallengeType, DeviceAttestation, Dns01Challenge, EcCurve, Error, Http01Challenge, Identifier,
+    Jwk, JwkThumbFields, KeyAuthorization, LetsEncrypt, NewAccount, NewOrder, OctetKeyCurve,
+    OrderState, OrderStatus, Problem, ProfileMeta, RevocationReason, RevocationRequest,
+    SigningAlgorithm, Subproblem, TlsAlpn01Challenge, ZeroSsl,
 };
 use types::{Directory, JoseJson, Signer};
 #[cfg(feature = "time")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,8 @@ pub use crypto::{
 
 mod order;
 pub use order::{
-    AuthorizationHandle, Authorizations, ChallengeHandle, Identifiers, Order, RetryPolicy,
+    AuthorizationHandle, Authorizations, DeviceAttest01ChallengeHandle, Dns01ChallengeHandle,
+    Http01ChallengeHandle, Identifiers, Order, RetryPolicy, TlsAlpn01ChallengeHandle,
 };
 
 mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,11 @@ mod types;
 pub use types::{
     AccountCredentials, Authorization, AuthorizationState, AuthorizationStatus,
     AuthorizedIdentifier, CertificateIdentifier, Challenge, ChallengeState, ChallengeStatus,
-    ChallengeType, DeviceAttestation, Dns01Challenge, EcCurve, Error, Http01Challenge, Identifier,
-    Jwk, JwkThumbFields, KeyAuthorization, LetsEncrypt, NewAccount, NewOrder, OctetKeyCurve,
-    OrderState, OrderStatus, Problem, ProfileMeta, RevocationReason, RevocationRequest,
-    SigningAlgorithm, Subproblem, TlsAlpn01Challenge, ZeroSsl,
+    ChallengeType, DeviceAttestation, Dns01Challenge, Dns01ChallengeAuthorization, EcCurve, Error,
+    Http01Challenge, Http01ChallengeAuthorization, Identifier, Jwk, JwkThumbFields, LetsEncrypt,
+    NewAccount, NewOrder, OctetKeyCurve, OrderState, OrderStatus, Problem, ProfileMeta,
+    RevocationReason, RevocationRequest, SigningAlgorithm, Subproblem, TlsAlpn01Challenge,
+    TlsAlpn01ChallengeAuthorization, ZeroSsl,
 };
 use types::{Directory, JoseJson, Signer};
 #[cfg(feature = "time")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,9 @@ use serde::Serialize;
 mod account;
 pub use account::{Account, AccountBuilder, ExternalAccountKey, Key};
 
+pub mod challenges;
+pub use challenges::{Challenge, ChallengeStatus, ChallengeType, DeviceAttestation};
+
 mod crypto;
 pub use crypto::{
     CryptoProvider, HmacKey, HmacKeyProvider, Sha256, SigningKey, SigningKeyProvider,
@@ -59,10 +62,9 @@ pub use order::{
 mod types;
 pub use types::{
     AccountCredentials, Authorization, AuthorizationState, AuthorizationStatus,
-    AuthorizedIdentifier, CertificateIdentifier, Challenge, ChallengeStatus, ChallengeType,
-    DeviceAttestation, EcCurve, Error, Identifier, Jwk, JwkThumbFields, LetsEncrypt, NewAccount,
-    NewOrder, OctetKeyCurve, OrderState, OrderStatus, Problem, ProfileMeta, RevocationReason,
-    RevocationRequest, SigningAlgorithm, Subproblem, ZeroSsl,
+    AuthorizedIdentifier, CertificateIdentifier, EcCurve, Error, Identifier, Jwk, JwkThumbFields,
+    LetsEncrypt, NewAccount, NewOrder, OctetKeyCurve, OrderState, OrderStatus, Problem, ProfileMeta,
+    RevocationReason, RevocationRequest, SigningAlgorithm, Subproblem, ZeroSsl,
 };
 use types::{Directory, JoseJson, Signer};
 #[cfg(feature = "time")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,16 +57,15 @@ pub use crypto::{
 
 mod order;
 pub use order::{
-    AuthorizationHandle, Authorizations, ChallengeHandle, Identifiers, KeyAuthorization, Order,
-    RetryPolicy,
+    AuthorizationHandle, Authorizations, Identifiers, KeyAuthorization, Order, RetryPolicy,
 };
 
 mod types;
 pub use types::{
     AccountCredentials, Authorization, AuthorizationState, AuthorizationStatus,
     AuthorizedIdentifier, CertificateIdentifier, EcCurve, Error, Identifier, Jwk, JwkThumbFields,
-    LetsEncrypt, NewAccount, NewOrder, OctetKeyCurve, OrderState, OrderStatus, Problem, ProfileMeta,
-    RevocationReason, RevocationRequest, SigningAlgorithm, Subproblem, ZeroSsl,
+    LetsEncrypt, NewAccount, NewOrder, OctetKeyCurve, OrderState, OrderStatus, Problem,
+    ProfileMeta, RevocationReason, RevocationRequest, SigningAlgorithm, Subproblem, ZeroSsl,
 };
 use types::{Directory, JoseJson, Signer};
 #[cfg(feature = "time")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,7 @@ mod account;
 pub use account::{Account, AccountBuilder, ExternalAccountKey, Key};
 
 pub mod challenges;
-pub use challenges::{
-    Challenge, ChallengeState, ChallengeStatus, ChallengeType, DeviceAttestation,
-};
+pub use challenges::{Challenge, ChallengeState, ChallengeStatus, DeviceAttestation};
 
 mod crypto;
 pub use crypto::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,9 @@ mod account;
 pub use account::{Account, AccountBuilder, ExternalAccountKey, Key};
 
 pub mod challenges;
-pub use challenges::{Challenge, ChallengeStatus, ChallengeType, DeviceAttestation};
+pub use challenges::{
+    Challenge, ChallengeState, ChallengeStatus, ChallengeType, DeviceAttestation,
+};
 
 mod crypto;
 pub use crypto::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,7 @@ pub use crypto::{
 };
 
 mod order;
-pub use order::{
-    AuthorizationHandle, Authorizations, Identifiers, KeyAuthorization, Order, RetryPolicy,
-};
+pub use order::{AuthorizationHandle, Authorizations, Identifiers, Order, RetryPolicy};
 
 mod types;
 pub use types::{

--- a/src/order.rs
+++ b/src/order.rs
@@ -395,7 +395,11 @@ impl<'a> AuthorizationHandle<'a> {
     ///
     /// Yields an object to interact with the challenge for the given type, if available.
     pub fn challenge(&'a mut self, r#type: ChallengeType) -> Option<ChallengeHandle<'a>> {
-        let challenge = self.state.challenges.iter().find(|c| c.r#type == r#type)?;
+        let challenge = self
+            .state
+            .challenges
+            .iter()
+            .find(|c| c.state.r#type() == r#type)?;
         Some(ChallengeHandle {
             identifier: self.state.identifier(),
             challenge,
@@ -472,7 +476,7 @@ impl ChallengeHandle<'_> {
         &mut self,
         payload: &DeviceAttestation<'_>,
     ) -> Result<ChallengeStatus, Error> {
-        if self.challenge.r#type != ChallengeType::DeviceAttest01 {
+        if self.challenge.state.r#type() != ChallengeType::DeviceAttest01 {
             return Err(Error::Str("challenge type should be device-attest-01"));
         }
 
@@ -499,13 +503,21 @@ impl ChallengeHandle<'_> {
         }
     }
 
-    /// Create a [`KeyAuthorization`] for this challenge
+    /// Create a [`KeyAuthorization`] for this challenge if applicable
     ///
     /// Combines a challenge's token with the thumbprint of the account's public key to compute
     /// the challenge's `KeyAuthorization`. The `KeyAuthorization` must be used to provision the
     /// expected challenge response based on the challenge type in use.
-    pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
-        KeyAuthorization::new(&self.challenge.token, &self.account.key)
+    ///
+    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a `KeyAuthorization`. Other challenge
+    /// types do not rely on this mechanism and will return `Ok(None)`, expecting the challenge to be
+    /// satisfied with another method specific to its type.
+    pub fn key_authorization(&self) -> Result<Option<KeyAuthorization>, Error> {
+        self.challenge
+            .state
+            .token()
+            .map(|t| KeyAuthorization::new(t, &self.account.key))
+            .transpose()
     }
 
     /// The identifier for this challenge's authorization

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 use std::ops::{ControlFlow, Deref};
+use std::slice;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
-use std::{fmt, slice};
 
 use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine};
 #[cfg(all(feature = "rcgen", any(feature = "aws-lc-rs", feature = "ring")))]
@@ -13,9 +13,10 @@ use tokio::time::sleep;
 use crate::account::AccountInner;
 use crate::types::{
     Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Challenge,
-    ChallengeType, DeviceAttestation, Empty, FinalizeRequest, OrderState, OrderStatus, Problem,
+    ChallengeType, DeviceAttestation, Empty, FinalizeRequest, KeyAuthorization, OrderState,
+    OrderStatus, Problem,
 };
-use crate::{ChallengeStatus, Error, Key, nonce_from_response, retry_after};
+use crate::{ChallengeStatus, Error, nonce_from_response, retry_after};
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
 ///
@@ -518,60 +519,6 @@ impl Deref for ChallengeHandle<'_> {
 
     fn deref(&self) -> &Self::Target {
         self.challenge
-    }
-}
-
-/// The response value to use for challenge responses
-///
-/// Refer to the methods below to see which encoding to use for your challenge type.
-///
-/// <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>
-pub struct KeyAuthorization {
-    inner: String,
-    digest: [u8; 32],
-}
-
-impl KeyAuthorization {
-    fn new(token: &str, key: &Key) -> Result<Self, Error> {
-        let inner = format!(
-            "{}.{}",
-            token,
-            BASE64_URL_SAFE_NO_PAD.encode(key.thumb_sha256()?)
-        );
-
-        Ok(Self {
-            digest: key.provider.sha256.hash(inner.as_bytes()),
-            inner,
-        })
-    }
-
-    /// Get the base64-encoded SHA256 digest of the key authorization
-    ///
-    /// This can be used for DNS-01 challenge responses.
-    pub fn dns_value(&self) -> String {
-        BASE64_URL_SAFE_NO_PAD.encode(self.digest)
-    }
-
-    /// Get the key authorization value
-    ///
-    /// This can be used for HTTP-01 challenge responses.
-    pub fn as_str(&self) -> &str {
-        &self.inner
-    }
-
-    /// Get the SHA-256 digest of the key authorization
-    ///
-    /// This can be used for TLS-ALPN-01 challenge responses.
-    ///
-    /// <https://datatracker.ietf.org/doc/html/rfc8737#section-3>
-    pub fn digest(&self) -> [u8; 32] {
-        self.digest
-    }
-}
-
-impl fmt::Debug for KeyAuthorization {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("KeyAuthorization").finish()
     }
 }
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -13,12 +13,13 @@ use tokio::time::sleep;
 use crate::account::AccountInner;
 use crate::types::{
     Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Challenge,
-    ChallengeStatus, ChallengeType, DeviceAttestation, Empty, Error, FinalizeRequest,
-    KeyAuthorization, OrderState, OrderStatus, Problem,
+    ChallengeStatus, ChallengeType, DeviceAttestation, Empty, Error, FinalizeRequest, OrderState,
+    OrderStatus, Problem,
 };
 use crate::{
-    ChallengeState, Dns01Challenge, Http01Challenge, TlsAlpn01Challenge, nonce_from_response,
-    retry_after,
+    ChallengeState, Dns01Challenge, Dns01ChallengeAuthorization, Http01Challenge,
+    Http01ChallengeAuthorization, TlsAlpn01Challenge, TlsAlpn01ChallengeAuthorization,
+    nonce_from_response, retry_after,
 };
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
@@ -510,9 +511,9 @@ impl Http01ChallengeHandle<'_> {
         &self.challenge.token
     }
 
-    /// Create a [`KeyAuthorization`] for this challenge
-    pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
-        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    /// Create a [`Http01ChallengeAuthorization`] for this challenge
+    pub fn authorization(&self) -> Result<Http01ChallengeAuthorization, Error> {
+        Http01ChallengeAuthorization::new(&self.challenge.token, &self.state.account.key)
     }
 }
 
@@ -546,9 +547,13 @@ impl Dns01ChallengeHandle<'_> {
         &self.challenge.token
     }
 
-    /// Create a [`KeyAuthorization`] for this challenge
-    pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
-        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    /// Create a [`Dns01ChallengeAuthorization`] for this challenge
+    pub fn authorization(&self) -> Result<Dns01ChallengeAuthorization, Error> {
+        Dns01ChallengeAuthorization::new(
+            self.state.identifier.identifier,
+            &self.challenge.token,
+            &self.state.account.key,
+        )
     }
 }
 
@@ -582,9 +587,9 @@ impl TlsAlpn01ChallengeHandle<'_> {
         &self.challenge.token
     }
 
-    /// Create a [`KeyAuthorization`] for this challenge
-    pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
-        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    /// Create a [`TlsAlpn01ChallengeAuthorization`] for this challenge
+    pub fn authorization(&self) -> Result<TlsAlpn01ChallengeAuthorization, Error> {
+        TlsAlpn01ChallengeAuthorization::new(&self.challenge.token, &self.state.account.key)
     }
 }
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -18,7 +18,7 @@ use crate::types::{
 };
 use crate::{
     ChallengeState, Dns01Challenge, Dns01ChallengeAuthorization, Http01Challenge,
-    Http01ChallengeAuthorization, TlsAlpn01Challenge, TlsAlpn01ChallengeAuthorization,
+    Http01ChallengeAuthorization, Identifier, TlsAlpn01Challenge, TlsAlpn01ChallengeAuthorization,
     nonce_from_response, retry_after,
 };
 
@@ -280,7 +280,7 @@ pub struct Identifiers<'a> {
 }
 
 impl<'a> Identifiers<'a> {
-    /// Yield the next [`Identifier`][crate::Identifier], fetching the authorization's state if
+    /// Yield the next [`Identifier`], fetching the authorization's state if
     /// we don't have it yet
     pub async fn next(&mut self) -> Option<Result<AuthorizedIdentifier<'a>, Error>> {
         Some(match self.inner.next().await? {
@@ -402,7 +402,17 @@ impl<'a> AuthorizationHandle<'a> {
     }
 
     /// Get a handle for the HTTP-01 challenge, if present
+    ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::Dns`] or [`Identifier::Ip`] type identifier.
     pub fn http01(&'a mut self) -> Option<Http01ChallengeHandle<'a>> {
+        if !matches!(
+            self.state.identifier().identifier,
+            Identifier::Dns(_) | Identifier::Ip(_)
+        ) {
+            return None;
+        }
+
         let challenge = challenge_for_type(&self.state.challenges, ChallengeType::Http01)?;
 
         let ChallengeState::Http01(data) = &challenge.state else {
@@ -421,7 +431,15 @@ impl<'a> AuthorizationHandle<'a> {
     }
 
     /// Get a handle for the DNS-01 challenge, if present
+    ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::Dns`] type identifier.
     pub fn dns01(&'a mut self) -> Option<Dns01ChallengeHandle<'a>> {
+        // Notably DNS-01 does not support IP address identifiers.
+        if !matches!(self.state.identifier().identifier, Identifier::Dns(_)) {
+            return None;
+        }
+
         let challenge = challenge_for_type(&self.state.challenges, ChallengeType::Dns01)?;
 
         let ChallengeState::Dns01(data) = &challenge.state else {
@@ -440,7 +458,17 @@ impl<'a> AuthorizationHandle<'a> {
     }
 
     /// Get a handle for the TLS-ALPN-01 challenge, if present
+    ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::Dns`] or [`Identifier::Ip`] type identifier.
     pub fn tls_alpn01(&'a mut self) -> Option<TlsAlpn01ChallengeHandle<'a>> {
+        if !matches!(
+            self.state.identifier().identifier,
+            Identifier::Dns(_) | Identifier::Ip(_)
+        ) {
+            return None;
+        }
+
         let challenge = challenge_for_type(&self.state.challenges, ChallengeType::TlsAlpn01)?;
 
         let ChallengeState::TlsAlpn01(data) = &challenge.state else {
@@ -460,8 +488,18 @@ impl<'a> AuthorizationHandle<'a> {
 
     /// Get a handle for the device-attest-01 challenge, if present
     ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::PermanentIdentifier`] or [`Identifier::HardwareModule`] type identifier.
+    ///
     /// Note: Device attestation support is experimental.
     pub fn device_attest01(&'a mut self) -> Option<DeviceAttest01ChallengeHandle<'a>> {
+        if !matches!(
+            self.state.identifier().identifier,
+            Identifier::PermanentIdentifier(_) | Identifier::HardwareModule(_)
+        ) {
+            return None;
+        }
+
         Some(DeviceAttest01ChallengeHandle {
             state: ChallengeHandleState {
                 identifier: self.state.identifier(),

--- a/src/order.rs
+++ b/src/order.rs
@@ -504,7 +504,7 @@ impl ChallengeHandle<'_> {
     /// the challenge's `KeyAuthorization`. The `KeyAuthorization` must be used to provision the
     /// expected challenge response based on the challenge type in use.
     pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
-        KeyAuthorization::new(self.challenge, &self.account.key)
+        KeyAuthorization::new(&self.challenge.token, &self.account.key)
     }
 
     /// The identifier for this challenge's authorization
@@ -532,10 +532,10 @@ pub struct KeyAuthorization {
 }
 
 impl KeyAuthorization {
-    fn new(challenge: &Challenge, key: &Key) -> Result<Self, Error> {
+    fn new(token: &str, key: &Key) -> Result<Self, Error> {
         let inner = format!(
             "{}.{}",
-            challenge.token,
+            token,
             BASE64_URL_SAFE_NO_PAD.encode(key.thumb_sha256()?)
         );
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -16,7 +16,10 @@ use crate::types::{
     ChallengeStatus, ChallengeType, DeviceAttestation, Empty, Error, FinalizeRequest,
     KeyAuthorization, OrderState, OrderStatus, Problem,
 };
-use crate::{nonce_from_response, retry_after};
+use crate::{
+    ChallengeState, Dns01Challenge, Http01Challenge, TlsAlpn01Challenge, nonce_from_response,
+    retry_after,
+};
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
 ///
@@ -321,8 +324,14 @@ impl<'a> AuthStream<'a> {
 /// For each authorization, you'll need to:
 ///
 /// * Select which [`ChallengeType`] you want to complete
-/// * Call [`AuthorizationHandle::challenge()`] to get a [`ChallengeHandle`]
-/// * Use the `ChallengeHandle` to complete the authorization's challenge
+/// * Call the appropriate challenge handle accessor to get a type specific challenge
+///   handle (e.g. [`AuthorizationHandle::http01()`], [`AuthorizationHandle::dns01()`],
+///   etc).
+/// * Use the handle to complete the authorization's challenge (e.g. provisioning an
+///   HTTP-01 response with [`Http01ChallengeHandle::authorization()`]).
+/// * Use the handle to indicate to the ACME CA that you're ready for validation to occur
+///   (e.g. for HTTP-01 with [`Http01ChallengeHandle::set_ready()`], or for device-attest-01
+///   with [`DeviceAttest01ChallengeHandle::send_attestation()`]).
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.3>
 pub struct AuthorizationHandle<'a> {
@@ -391,20 +400,77 @@ impl<'a> AuthorizationHandle<'a> {
         }
     }
 
-    /// Get a [`ChallengeHandle`] for the given `type`
+    /// Get a handle for the HTTP-01 challenge, if present
+    pub fn http01(&'a mut self) -> Option<Http01ChallengeHandle<'a>> {
+        let challenge = challenge_for_type(&self.state.challenges, ChallengeType::Http01)?;
+
+        let ChallengeState::Http01(data) = &challenge.state else {
+            return None;
+        };
+
+        Some(Http01ChallengeHandle {
+            state: ChallengeHandleState {
+                identifier: self.state.identifier(),
+                challenge,
+                nonce: self.nonce,
+                account: self.account,
+            },
+            challenge: data,
+        })
+    }
+
+    /// Get a handle for the DNS-01 challenge, if present
+    pub fn dns01(&'a mut self) -> Option<Dns01ChallengeHandle<'a>> {
+        let challenge = challenge_for_type(&self.state.challenges, ChallengeType::Dns01)?;
+
+        let ChallengeState::Dns01(data) = &challenge.state else {
+            return None;
+        };
+
+        Some(Dns01ChallengeHandle {
+            state: ChallengeHandleState {
+                identifier: self.state.identifier(),
+                challenge,
+                nonce: self.nonce,
+                account: self.account,
+            },
+            challenge: data,
+        })
+    }
+
+    /// Get a handle for the TLS-ALPN-01 challenge, if present
+    pub fn tls_alpn01(&'a mut self) -> Option<TlsAlpn01ChallengeHandle<'a>> {
+        let challenge = challenge_for_type(&self.state.challenges, ChallengeType::TlsAlpn01)?;
+
+        let ChallengeState::TlsAlpn01(data) = &challenge.state else {
+            return None;
+        };
+
+        Some(TlsAlpn01ChallengeHandle {
+            state: ChallengeHandleState {
+                identifier: self.state.identifier(),
+                challenge,
+                nonce: self.nonce,
+                account: self.account,
+            },
+            challenge: data,
+        })
+    }
+
+    /// Get a handle for the device-attest-01 challenge, if present
     ///
-    /// Yields an object to interact with the challenge for the given type, if available.
-    pub fn challenge(&'a mut self, r#type: ChallengeType) -> Option<ChallengeHandle<'a>> {
-        let challenge = self
-            .state
-            .challenges
-            .iter()
-            .find(|c| c.state.r#type() == r#type)?;
-        Some(ChallengeHandle {
-            identifier: self.state.identifier(),
-            challenge,
-            nonce: self.nonce,
-            account: self.account,
+    /// Note: Device attestation support is experimental.
+    pub fn device_attest01(&'a mut self) -> Option<DeviceAttest01ChallengeHandle<'a>> {
+        Some(DeviceAttest01ChallengeHandle {
+            state: ChallengeHandleState {
+                identifier: self.state.identifier(),
+                challenge: challenge_for_type(
+                    &self.state.challenges,
+                    ChallengeType::DeviceAttest01,
+                )?,
+                nonce: self.nonce,
+                account: self.account,
+            },
         })
     }
 
@@ -422,64 +488,132 @@ impl Deref for AuthorizationHandle<'_> {
     }
 }
 
-/// Wrapper type for interacting with a [`Challenge`]'s state
-///
-/// For each challenge, you'll need to:
-///
-/// * Obtain the [`ChallengeHandle::key_authorization()`] for the challenge response
-/// * Set up the challenge response in your infrastructure (details vary by challenge type)
-/// * Call [`ChallengeHandle::set_ready()`] for that challenge after setup is complete
-///
-/// After the challenges have been set to ready, call [`Order::poll_ready()`] to wait until the
-/// order is ready to be finalized (or to learn if it becomes invalid). Once it is ready, call
-/// [`Order::finalize()`] to get the certificate.
-///
-/// Dereferences to the underlying [`Challenge`] for easy access to the challenge's state.
-pub struct ChallengeHandle<'a> {
-    identifier: AuthorizedIdentifier<'a>,
-    challenge: &'a Challenge,
-    nonce: &'a mut Option<String>,
-    account: &'a AccountInner,
+/// Handle for RFC 8555 HTTP-01 challenges
+pub struct Http01ChallengeHandle<'a> {
+    state: ChallengeHandleState<'a>,
+    challenge: &'a Http01Challenge,
 }
 
-impl ChallengeHandle<'_> {
-    /// Notify the server that the given challenge is ready to be completed
+impl Http01ChallengeHandle<'_> {
+    /// Notify the server that the challenge is ready to be completed
     pub async fn set_ready(&mut self) -> Result<(), Error> {
-        let rsp = self
-            .account
-            .post(Some(&Empty {}), self.nonce.take(), &self.challenge.url)
-            .await?;
-
-        *self.nonce = nonce_from_response(&rsp);
-        let response = Problem::check::<Challenge>(rsp).await?;
-        match response.error {
-            Some(details) => Err(Error::Api(details)),
-            None => Ok(()),
-        }
+        self.state.set_ready().await
     }
 
+    /// The identifier for this challenge's authorization
+    pub fn identifier(&self) -> &AuthorizedIdentifier<'_> {
+        &self.state.identifier
+    }
+
+    /// The token for this challenge
+    pub fn token(&self) -> &str {
+        &self.challenge.token
+    }
+
+    /// Create a [`KeyAuthorization`] for this challenge
+    pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
+        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    }
+}
+
+impl Deref for Http01ChallengeHandle<'_> {
+    type Target = Challenge;
+
+    fn deref(&self) -> &Self::Target {
+        self.state.challenge
+    }
+}
+
+/// Handle for RFC 8555 DNS-01 challenges
+pub struct Dns01ChallengeHandle<'a> {
+    state: ChallengeHandleState<'a>,
+    challenge: &'a Dns01Challenge,
+}
+
+impl Dns01ChallengeHandle<'_> {
+    /// Notify the server that the challenge is ready to be completed
+    pub async fn set_ready(&mut self) -> Result<(), Error> {
+        self.state.set_ready().await
+    }
+
+    /// The identifier for this challenge's authorization
+    pub fn identifier(&self) -> &AuthorizedIdentifier<'_> {
+        &self.state.identifier
+    }
+
+    /// The token for this challenge
+    pub fn token(&self) -> &str {
+        &self.challenge.token
+    }
+
+    /// Create a [`KeyAuthorization`] for this challenge
+    pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
+        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    }
+}
+
+impl Deref for Dns01ChallengeHandle<'_> {
+    type Target = Challenge;
+
+    fn deref(&self) -> &Self::Target {
+        self.state.challenge
+    }
+}
+
+/// Handle for RFC 8737 TLS-ALPN-01 challenges
+pub struct TlsAlpn01ChallengeHandle<'a> {
+    state: ChallengeHandleState<'a>,
+    challenge: &'a TlsAlpn01Challenge,
+}
+
+impl TlsAlpn01ChallengeHandle<'_> {
+    /// Notify the server that the challenge is ready to be completed
+    pub async fn set_ready(&mut self) -> Result<(), Error> {
+        self.state.set_ready().await
+    }
+
+    /// The identifier for this challenge's authorization
+    pub fn identifier(&self) -> &AuthorizedIdentifier<'_> {
+        &self.state.identifier
+    }
+
+    /// The token for this challenge
+    pub fn token(&self) -> &str {
+        &self.challenge.token
+    }
+
+    /// Create a [`KeyAuthorization`] for this challenge
+    pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
+        KeyAuthorization::new(&self.challenge.token, &self.state.account.key)
+    }
+}
+
+impl Deref for TlsAlpn01ChallengeHandle<'_> {
+    type Target = Challenge;
+
+    fn deref(&self) -> &Self::Target {
+        self.state.challenge
+    }
+}
+
+/// Handle for draft-ietf-acme-device-attest device-attest-01 challenges
+///
+/// Note: device attestation support is experimental.
+pub struct DeviceAttest01ChallengeHandle<'a> {
+    state: ChallengeHandleState<'a>,
+}
+
+impl DeviceAttest01ChallengeHandle<'_> {
     /// Notify the server that the challenge is ready by sending a device attestation
     ///
-    /// This function is for the ACME challenge device-attest-01. It should not be used
-    /// with other challenge types.
-    /// See <https://datatracker.ietf.org/doc/draft-acme-device-attest/> for details.
+    /// See <https://datatracker.ietf.org/doc/draft-ietf-acme-device-attest/> for details.
     ///
-    /// `payload` is the device attestation object as defined in link. Provide the attestation
-    /// object as a raw blob. Base64 encoding of the attestation object `payload.att_obj`
-    /// is done by this function.
-    ///
-    /// The function yields the challenge status from the ACME server that validated the
-    /// attestation challenge.
-    ///
-    /// Note: Device attestation support is experimental.
-    pub async fn send_device_attestation(
+    /// `payload` is the device attestation object. Provide the attestation
+    /// object as a raw blob; base64 encoding is done by this function.
+    pub async fn send_attestation(
         &mut self,
         payload: &DeviceAttestation<'_>,
     ) -> Result<ChallengeStatus, Error> {
-        if self.challenge.state.r#type() != ChallengeType::DeviceAttest01 {
-            return Err(Error::Str("challenge type should be device-attest-01"));
-        }
-
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
         struct DeviceAttestationBase64<'a> {
@@ -491,11 +625,16 @@ impl ChallengeHandle<'_> {
         };
 
         let rsp = self
+            .state
             .account
-            .post(Some(&payload), self.nonce.take(), &self.challenge.url)
+            .post(
+                Some(&payload),
+                self.state.nonce.take(),
+                &self.state.challenge.url,
+            )
             .await?;
 
-        *self.nonce = nonce_from_response(&rsp);
+        *self.state.nonce = nonce_from_response(&rsp);
         let response = Problem::check::<Challenge>(rsp).await?;
         match response.error {
             Some(details) => Err(Error::Api(details)),
@@ -503,34 +642,17 @@ impl ChallengeHandle<'_> {
         }
     }
 
-    /// Create a [`KeyAuthorization`] for this challenge if applicable
-    ///
-    /// Combines a challenge's token with the thumbprint of the account's public key to compute
-    /// the challenge's `KeyAuthorization`. The `KeyAuthorization` must be used to provision the
-    /// expected challenge response based on the challenge type in use.
-    ///
-    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a `KeyAuthorization`. Other challenge
-    /// types do not rely on this mechanism and will return `Ok(None)`, expecting the challenge to be
-    /// satisfied with another method specific to its type.
-    pub fn key_authorization(&self) -> Result<Option<KeyAuthorization>, Error> {
-        self.challenge
-            .state
-            .token()
-            .map(|t| KeyAuthorization::new(t, &self.account.key))
-            .transpose()
-    }
-
     /// The identifier for this challenge's authorization
     pub fn identifier(&self) -> &AuthorizedIdentifier<'_> {
-        &self.identifier
+        &self.state.identifier
     }
 }
 
-impl Deref for ChallengeHandle<'_> {
+impl Deref for DeviceAttest01ChallengeHandle<'_> {
     type Target = Challenge;
 
     fn deref(&self) -> &Self::Target {
-        self.challenge
+        self.state.challenge
     }
 }
 
@@ -625,4 +747,33 @@ impl RetryState {
             false => ControlFlow::Continue(()),
         }
     }
+}
+
+/// Shared state common to all challenges
+struct ChallengeHandleState<'a> {
+    identifier: AuthorizedIdentifier<'a>,
+    challenge: &'a Challenge,
+    nonce: &'a mut Option<String>,
+    account: &'a AccountInner,
+}
+
+impl ChallengeHandleState<'_> {
+    /// Notify the server that the given challenge is ready to be completed
+    async fn set_ready(&mut self) -> Result<(), Error> {
+        let rsp = self
+            .account
+            .post(Some(&Empty {}), self.nonce.take(), &self.challenge.url)
+            .await?;
+
+        *self.nonce = nonce_from_response(&rsp);
+        let response = Problem::check::<Challenge>(rsp).await?;
+        match response.error {
+            Some(details) => Err(Error::Api(details)),
+            None => Ok(()),
+        }
+    }
+}
+
+fn challenge_for_type(challenges: &[Challenge], r#type: ChallengeType) -> Option<&Challenge> {
+    challenges.iter().find(|c| c.state.r#type() == r#type)
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -13,10 +13,10 @@ use tokio::time::sleep;
 use crate::account::AccountInner;
 use crate::types::{
     Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Challenge,
-    ChallengeType, DeviceAttestation, Empty, FinalizeRequest, KeyAuthorization, OrderState,
-    OrderStatus, Problem,
+    ChallengeStatus, ChallengeType, DeviceAttestation, Empty, Error, FinalizeRequest,
+    KeyAuthorization, OrderState, OrderStatus, Problem,
 };
-use crate::{ChallengeStatus, Error, nonce_from_response, retry_after};
+use crate::{nonce_from_response, retry_after};
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
 ///

--- a/src/order.rs
+++ b/src/order.rs
@@ -13,9 +13,10 @@ use tokio::time::sleep;
 use crate::account::AccountInner;
 use crate::types::{
     Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Challenge,
-    ChallengeType, DeviceAttestation, Empty, FinalizeRequest, OrderState, OrderStatus, Problem,
+    ChallengeStatus, ChallengeType, DeviceAttestation, Empty, Error, FinalizeRequest, OrderState,
+    OrderStatus, Problem,
 };
-use crate::{ChallengeStatus, Error, Key, nonce_from_response, retry_after};
+use crate::{Key, nonce_from_response, retry_after};
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
 ///

--- a/src/order.rs
+++ b/src/order.rs
@@ -11,10 +11,10 @@ use serde::Serialize;
 use tokio::time::sleep;
 
 use crate::account::AccountInner;
+use crate::challenges::{Challenge, ChallengeStatus, ChallengeType, DeviceAttestation};
 use crate::types::{
-    Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Challenge,
-    ChallengeStatus, ChallengeType, DeviceAttestation, Empty, Error, FinalizeRequest, OrderState,
-    OrderStatus, Problem,
+    Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Empty, Error,
+    FinalizeRequest, OrderState, OrderStatus, Problem,
 };
 use crate::{Key, nonce_from_response, retry_after};
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,9 +1,8 @@
 use std::ops::{ControlFlow, Deref};
+use std::slice;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
-use std::{fmt, slice};
 
-use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine};
 #[cfg(all(feature = "rcgen", any(feature = "aws-lc-rs", feature = "ring")))]
 use rcgen::{CertificateParams, DistinguishedName, KeyPair};
 use serde::Serialize;
@@ -15,7 +14,7 @@ use crate::types::{
     Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Empty, Error,
     FinalizeRequest, OrderState, OrderStatus, Problem,
 };
-use crate::{Key, nonce_from_response, retry_after};
+use crate::{nonce_from_response, retry_after};
 
 /// An ACME order as described in RFC 8555 (section 7.1.3)
 ///
@@ -324,7 +323,7 @@ impl<'a> AuthStream<'a> {
 ///   handle (e.g. [`AuthorizationHandle::http01()`], [`AuthorizationHandle::dns01()`],
 ///   etc).
 /// * Use the type-specific handle API to complete the authorization's challenge (e.g.
-///   provisioning an HTTP-01 response with [`http01::Handle::key_authorization()`]).
+///   provisioning an HTTP-01 response with [`http01::Handle::response()`]).
 /// * Use the type-specific handle API to indicate to the ACME CA that you're ready for
 ///   validation to occur (e.g. [`http01::Handle::set_ready()`] for HTTP-01, or
 ///   [`device_attest01::Handle::send_attestation()`] for device-attest-01).
@@ -433,56 +432,6 @@ impl Deref for AuthorizationHandle<'_> {
 
     fn deref(&self) -> &Self::Target {
         self.state
-    }
-}
-
-/// The response value to use for challenge responses
-///
-/// Refer to the methods below to see which encoding to use for your challenge type.
-///
-/// <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>
-pub struct KeyAuthorization {
-    inner: String,
-    digest: [u8; 32],
-}
-
-impl KeyAuthorization {
-    pub(crate) fn new(token: &str, key: &Key) -> Result<Self, Error> {
-        let inner = format!("{}.{}", token, key.thumbprint());
-
-        Ok(Self {
-            digest: key.provider.sha256.hash(inner.as_bytes()),
-            inner,
-        })
-    }
-
-    /// Get the base64-encoded SHA256 digest of the key authorization
-    ///
-    /// This can be used for DNS-01 challenge responses.
-    pub fn dns_value(&self) -> String {
-        BASE64_URL_SAFE_NO_PAD.encode(self.digest)
-    }
-
-    /// Get the key authorization value
-    ///
-    /// This can be used for HTTP-01 challenge responses.
-    pub fn as_str(&self) -> &str {
-        &self.inner
-    }
-
-    /// Get the SHA-256 digest of the key authorization
-    ///
-    /// This can be used for TLS-ALPN-01 challenge responses.
-    ///
-    /// <https://datatracker.ietf.org/doc/html/rfc8737#section-3>
-    pub fn digest(&self) -> [u8; 32] {
-        self.digest
-    }
-}
-
-impl fmt::Debug for KeyAuthorization {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("KeyAuthorization").finish()
     }
 }
 

--- a/src/order.rs
+++ b/src/order.rs
@@ -448,11 +448,7 @@ pub struct KeyAuthorization {
 
 impl KeyAuthorization {
     pub(crate) fn new(token: &str, key: &Key) -> Result<Self, Error> {
-        let inner = format!(
-            "{}.{}",
-            token,
-            BASE64_URL_SAFE_NO_PAD.encode(key.thumb_sha256()?)
-        );
+        let inner = format!("{}.{}", token, key.thumbprint());
 
         Ok(Self {
             digest: key.provider.sha256.hash(inner.as_bytes()),

--- a/src/order.rs
+++ b/src/order.rs
@@ -319,7 +319,7 @@ impl<'a> AuthStream<'a> {
 ///
 /// For each authorization, you'll need to:
 ///
-/// * Select which [`ChallengeType`][crate::ChallengeType] you want to complete
+/// * Decide which challenge type you want to complete
 /// * Call the appropriate challenge handle accessor to get a type specific challenge
 ///   handle (e.g. [`AuthorizationHandle::http01()`], [`AuthorizationHandle::dns01()`],
 ///   etc).

--- a/src/order.rs
+++ b/src/order.rs
@@ -396,24 +396,40 @@ impl<'a> AuthorizationHandle<'a> {
     }
 
     /// Get a handle for the HTTP-01 challenge, if present
+    ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::Dns`][crate::Identifier::Dns] or [`Identifier::Ip`][crate::Identifier::Ip]
+    /// type identifier.
     #[must_use = "the returned challenge handle should be used to complete the authorization"]
     pub fn http01(&mut self) -> Option<http01::Handle<'_>> {
         ChallengeHandle::new(self.state, self.nonce, self.account)
     }
 
     /// Get a handle for the DNS-01 challenge, if present
+    ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::Dns`][crate::Identifier::Dns] type identifier. Notably, DNS-01 does not
+    /// support IP address identifiers.
     #[must_use = "the returned challenge handle should be used to complete the authorization"]
     pub fn dns01(&mut self) -> Option<dns01::Handle<'_>> {
         ChallengeHandle::new(self.state, self.nonce, self.account)
     }
 
     /// Get a handle for the TLS-ALPN-01 challenge, if present
+    ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::Dns`][crate::Identifier::Dns] or [`Identifier::Ip`][crate::Identifier::Ip]
+    /// type identifier.
     #[must_use = "the returned challenge handle should be used to complete the authorization"]
     pub fn tls_alpn01(&mut self) -> Option<tls_alpn01::Handle<'_>> {
         ChallengeHandle::new(self.state, self.nonce, self.account)
     }
 
     /// Get a handle for the device-attest-01 challenge, if present
+    ///
+    /// Returns `None` if the challenge type isn't offered, or the challenge identifier is not
+    /// a [`Identifier::PermanentIdentifier`][crate::Identifier::PermanentIdentifier] or
+    /// [`Identifier::HardwareModule`][crate::Identifier::HardwareModule] type identifier.
     ///
     /// Note: Device attestation support is experimental.
     #[must_use = "the returned challenge handle should be used to complete the authorization"]

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::ops::{ControlFlow, Deref};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
@@ -11,7 +10,7 @@ use serde::Serialize;
 use tokio::time::sleep;
 
 use crate::account::AccountInner;
-use crate::challenges::{Challenge, ChallengeStatus, ChallengeType, DeviceAttestation};
+use crate::challenges::{ChallengeHandle, device_attest01, dns01, http01, tls_alpn01};
 use crate::types::{
     Authorization, AuthorizationState, AuthorizationStatus, AuthorizedIdentifier, Empty, Error,
     FinalizeRequest, OrderState, OrderStatus, Problem,
@@ -320,9 +319,15 @@ impl<'a> AuthStream<'a> {
 ///
 /// For each authorization, you'll need to:
 ///
-/// * Select which [`ChallengeType`] you want to complete
-/// * Call [`AuthorizationHandle::challenge()`] to get a [`ChallengeHandle`]
-/// * Use the `ChallengeHandle` to complete the authorization's challenge
+/// * Select which [`ChallengeType`][crate::ChallengeType] you want to complete
+/// * Call the appropriate challenge handle accessor to get a type specific challenge
+///   handle (e.g. [`AuthorizationHandle::http01()`], [`AuthorizationHandle::dns01()`],
+///   etc).
+/// * Use the type-specific handle API to complete the authorization's challenge (e.g.
+///   provisioning an HTTP-01 response with [`http01::Handle::key_authorization()`]).
+/// * Use the type-specific handle API to indicate to the ACME CA that you're ready for
+///   validation to occur (e.g. [`http01::Handle::set_ready()`] for HTTP-01, or
+///   [`device_attest01::Handle::send_attestation()`] for device-attest-01).
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.3>
 pub struct AuthorizationHandle<'a> {
@@ -391,21 +396,30 @@ impl<'a> AuthorizationHandle<'a> {
         }
     }
 
-    /// Get a [`ChallengeHandle`] for the given `type`
+    /// Get a handle for the HTTP-01 challenge, if present
+    #[must_use = "the returned challenge handle should be used to complete the authorization"]
+    pub fn http01(&mut self) -> Option<http01::Handle<'_>> {
+        ChallengeHandle::new(self.state, self.nonce, self.account)
+    }
+
+    /// Get a handle for the DNS-01 challenge, if present
+    #[must_use = "the returned challenge handle should be used to complete the authorization"]
+    pub fn dns01(&mut self) -> Option<dns01::Handle<'_>> {
+        ChallengeHandle::new(self.state, self.nonce, self.account)
+    }
+
+    /// Get a handle for the TLS-ALPN-01 challenge, if present
+    #[must_use = "the returned challenge handle should be used to complete the authorization"]
+    pub fn tls_alpn01(&mut self) -> Option<tls_alpn01::Handle<'_>> {
+        ChallengeHandle::new(self.state, self.nonce, self.account)
+    }
+
+    /// Get a handle for the device-attest-01 challenge, if present
     ///
-    /// Yields an object to interact with the challenge for the given type, if available.
-    pub fn challenge(&'a mut self, r#type: ChallengeType) -> Option<ChallengeHandle<'a>> {
-        let challenge = self
-            .state
-            .challenges
-            .iter()
-            .find(|c| c.state.r#type() == r#type)?;
-        Some(ChallengeHandle {
-            identifier: self.state.identifier(),
-            challenge,
-            nonce: self.nonce,
-            account: self.account,
-        })
+    /// Note: Device attestation support is experimental.
+    #[must_use = "the returned challenge handle should be used to complete the authorization"]
+    pub fn device_attest01(&mut self) -> Option<device_attest01::Handle<'_>> {
+        ChallengeHandle::new(self.state, self.nonce, self.account)
     }
 
     /// Get the URL of the authorization
@@ -422,118 +436,6 @@ impl Deref for AuthorizationHandle<'_> {
     }
 }
 
-/// Wrapper type for interacting with a [`Challenge`]'s state
-///
-/// For each challenge, you'll need to:
-///
-/// * Obtain the [`ChallengeHandle::key_authorization()`] for the challenge response
-/// * Set up the challenge response in your infrastructure (details vary by challenge type)
-/// * Call [`ChallengeHandle::set_ready()`] for that challenge after setup is complete
-///
-/// After the challenges have been set to ready, call [`Order::poll_ready()`] to wait until the
-/// order is ready to be finalized (or to learn if it becomes invalid). Once it is ready, call
-/// [`Order::finalize()`] to get the certificate.
-///
-/// Dereferences to the underlying [`Challenge`] for easy access to the challenge's state.
-pub struct ChallengeHandle<'a> {
-    identifier: AuthorizedIdentifier<'a>,
-    challenge: &'a Challenge,
-    nonce: &'a mut Option<String>,
-    account: &'a AccountInner,
-}
-
-impl ChallengeHandle<'_> {
-    /// Notify the server that the given challenge is ready to be completed
-    pub async fn set_ready(&mut self) -> Result<(), Error> {
-        let rsp = self
-            .account
-            .post(Some(&Empty {}), self.nonce.take(), &self.challenge.url)
-            .await?;
-
-        *self.nonce = nonce_from_response(&rsp);
-        let response = Problem::check::<Challenge>(rsp).await?;
-        match response.error {
-            Some(details) => Err(Error::Api(details)),
-            None => Ok(()),
-        }
-    }
-
-    /// Notify the server that the challenge is ready by sending a device attestation
-    ///
-    /// This function is for the ACME challenge device-attest-01. It should not be used
-    /// with other challenge types.
-    /// See <https://datatracker.ietf.org/doc/draft-acme-device-attest/> for details.
-    ///
-    /// `payload` is the device attestation object as defined in link. Provide the attestation
-    /// object as a raw blob. Base64 encoding of the attestation object `payload.att_obj`
-    /// is done by this function.
-    ///
-    /// The function yields the challenge status from the ACME server that validated the
-    /// attestation challenge.
-    ///
-    /// Note: Device attestation support is experimental.
-    pub async fn send_device_attestation(
-        &mut self,
-        payload: &DeviceAttestation<'_>,
-    ) -> Result<ChallengeStatus, Error> {
-        if self.challenge.state.r#type() != ChallengeType::DeviceAttest01 {
-            return Err(Error::Str("challenge type should be device-attest-01"));
-        }
-
-        #[derive(Serialize)]
-        #[serde(rename_all = "camelCase")]
-        struct DeviceAttestationBase64<'a> {
-            att_obj: Cow<'a, str>,
-        }
-
-        let payload = DeviceAttestationBase64 {
-            att_obj: Cow::Owned(BASE64_URL_SAFE_NO_PAD.encode(&payload.att_obj)),
-        };
-
-        let rsp = self
-            .account
-            .post(Some(&payload), self.nonce.take(), &self.challenge.url)
-            .await?;
-
-        *self.nonce = nonce_from_response(&rsp);
-        let response = Problem::check::<Challenge>(rsp).await?;
-        match response.error {
-            Some(details) => Err(Error::Api(details)),
-            None => Ok(response.status),
-        }
-    }
-
-    /// Create a [`KeyAuthorization`] for this challenge if applicable
-    ///
-    /// Combines a challenge's token with the thumbprint of the account's public key to compute
-    /// the challenge's `KeyAuthorization`. The `KeyAuthorization` must be used to provision the
-    /// expected challenge response based on the challenge type in use.
-    ///
-    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a `KeyAuthorization`. Other challenge
-    /// types do not rely on this mechanism and will return `Ok(None)`, expecting the challenge to be
-    /// satisfied with another method specific to its type.
-    pub fn key_authorization(&self) -> Result<Option<KeyAuthorization>, Error> {
-        self.challenge
-            .state
-            .token()
-            .map(|t| KeyAuthorization::new(t, &self.account.key))
-            .transpose()
-    }
-
-    /// The identifier for this challenge's authorization
-    pub fn identifier(&self) -> &AuthorizedIdentifier<'_> {
-        &self.identifier
-    }
-}
-
-impl Deref for ChallengeHandle<'_> {
-    type Target = Challenge;
-
-    fn deref(&self) -> &Self::Target {
-        self.challenge
-    }
-}
-
 /// The response value to use for challenge responses
 ///
 /// Refer to the methods below to see which encoding to use for your challenge type.
@@ -545,7 +447,7 @@ pub struct KeyAuthorization {
 }
 
 impl KeyAuthorization {
-    fn new(token: &str, key: &Key) -> Result<Self, Error> {
+    pub(crate) fn new(token: &str, key: &Key) -> Result<Self, Error> {
         let inner = format!(
             "{}.{}",
             token,

--- a/src/order.rs
+++ b/src/order.rs
@@ -395,7 +395,11 @@ impl<'a> AuthorizationHandle<'a> {
     ///
     /// Yields an object to interact with the challenge for the given type, if available.
     pub fn challenge(&'a mut self, r#type: ChallengeType) -> Option<ChallengeHandle<'a>> {
-        let challenge = self.state.challenges.iter().find(|c| c.r#type == r#type)?;
+        let challenge = self
+            .state
+            .challenges
+            .iter()
+            .find(|c| c.state.r#type() == r#type)?;
         Some(ChallengeHandle {
             identifier: self.state.identifier(),
             challenge,
@@ -472,7 +476,7 @@ impl ChallengeHandle<'_> {
         &mut self,
         payload: &DeviceAttestation<'_>,
     ) -> Result<ChallengeStatus, Error> {
-        if self.challenge.r#type != ChallengeType::DeviceAttest01 {
+        if self.challenge.state.r#type() != ChallengeType::DeviceAttest01 {
             return Err(Error::Str("challenge type should be device-attest-01"));
         }
 
@@ -499,13 +503,21 @@ impl ChallengeHandle<'_> {
         }
     }
 
-    /// Create a [`KeyAuthorization`] for this challenge
+    /// Create a [`KeyAuthorization`] for this challenge if applicable
     ///
     /// Combines a challenge's token with the thumbprint of the account's public key to compute
     /// the challenge's `KeyAuthorization`. The `KeyAuthorization` must be used to provision the
     /// expected challenge response based on the challenge type in use.
-    pub fn key_authorization(&self) -> Result<KeyAuthorization, Error> {
-        KeyAuthorization::new(self.challenge, &self.account.key)
+    ///
+    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a `KeyAuthorization`. Other challenge
+    /// types do not rely on this mechanism and will return `Ok(None)`, expecting the challenge to be
+    /// satisfied with another method specific to its type.
+    pub fn key_authorization(&self) -> Result<Option<KeyAuthorization>, Error> {
+        self.challenge
+            .state
+            .token()
+            .map(|t| KeyAuthorization::new(t, &self.account.key))
+            .transpose()
     }
 
     /// The identifier for this challenge's authorization
@@ -533,10 +545,10 @@ pub struct KeyAuthorization {
 }
 
 impl KeyAuthorization {
-    fn new(challenge: &Challenge, key: &Key) -> Result<Self, Error> {
+    fn new(token: &str, key: &Key) -> Result<Self, Error> {
         let inner = format!(
             "{}.{}",
-            challenge.token,
+            token,
             BASE64_URL_SAFE_NO_PAD.encode(key.thumb_sha256()?)
         );
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -762,19 +762,89 @@ impl fmt::Display for AuthorizedIdentifier<'_> {
 /// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.5>
 #[derive(Debug, Deserialize)]
 pub struct Challenge {
-    /// Type of challenge
-    pub r#type: ChallengeType,
     /// Challenge identifier
     pub url: String,
-    /// Token for this challenge
-    ///
-    /// Unknown `ChallengeType` instances may omit this field, leaving it empty.
-    #[serde(default)]
-    pub token: String,
+    /// Challenge type specific state
+    #[serde(flatten)]
+    pub state: ChallengeState,
     /// Current status
     pub status: ChallengeStatus,
     /// Potential error state
     pub error: Option<Problem>,
+}
+
+/// Challenge type specific state
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ChallengeState {
+    /// State for an RFC 8555 HTTP-01 challenge
+    Http01(Http01Challenge),
+    /// State for an RFC 8555 DNS-01 challenge
+    Dns01(Dns01Challenge),
+    /// State for an RFC 8737 TLS-ALPN-01 challenge
+    TlsAlpn01(TlsAlpn01Challenge),
+    /// State for a draft-acme-device-attest-08 challenge
+    ///
+    /// Note: Device attestation support is experimental
+    DeviceAttest01,
+    /// An unknown challenge type
+    Unknown(String),
+}
+
+impl ChallengeState {
+    /// Get the challenge type associated with this challenge state
+    pub fn r#type(&self) -> ChallengeType {
+        match self {
+            Self::Http01(_) => ChallengeType::Http01,
+            Self::Dns01(_) => ChallengeType::Dns01,
+            Self::TlsAlpn01(_) => ChallengeType::TlsAlpn01,
+            Self::DeviceAttest01 => ChallengeType::DeviceAttest01,
+            Self::Unknown(r#type) => ChallengeType::Unknown(r#type.clone()),
+        }
+    }
+
+    /// Get the token associated with this challenge (if applicable)
+    ///
+    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a token. Other challenge types
+    /// do not rely on RFC 8555 key authorizations and will return `None`, expecting the
+    /// challenge to be satisfied with another method specific to its type.
+    pub fn token(&self) -> Option<&str> {
+        Some(match self {
+            Self::Http01(Http01Challenge { token })
+            | Self::Dns01(Dns01Challenge { token })
+            | Self::TlsAlpn01(TlsAlpn01Challenge { token }) => token,
+            Self::DeviceAttest01 | Self::Unknown { .. } => return None,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for ChallengeState {
+    // Deriving `Deserialize` for the `ChallengeState` enum w/ an untagged variant
+    // for unknown challenge types would mean we swallow deser errors for _known_
+    // challenge types. Instead, we want to deser the type string, and then either
+    // capture it as an `Unknown` variant, or dispatch the full value to a more specific
+    // challenge deser, propagating an error result if necessary.
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+
+        let r#type = value["type"]
+            .as_str()
+            .ok_or_else(|| de::Error::missing_field("type"))?;
+
+        match r#type {
+            "http-01" => serde_json::from_value(value)
+                .map(Self::Http01)
+                .map_err(de::Error::custom),
+            "dns-01" => serde_json::from_value(value)
+                .map(Self::Dns01)
+                .map_err(de::Error::custom),
+            "tls-alpn-01" => serde_json::from_value(value)
+                .map(Self::TlsAlpn01)
+                .map_err(de::Error::custom),
+            "device-attest-01" => Ok(Self::DeviceAttest01),
+            unknown_type => Ok(Self::Unknown(unknown_type.to_owned())),
+        }
+    }
 }
 
 /// The challenge type
@@ -793,6 +863,36 @@ pub enum ChallengeType {
     DeviceAttest01,
     #[serde(untagged)]
     Unknown(String),
+}
+
+/// Challenge state for an RFC 8555 http-01 challenge
+///
+/// See <https://www.rfc-editor.org/rfc/rfc8555#section-8.3>
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct Http01Challenge {
+    /// A token for constructing a key authorization to complete this challenge
+    pub token: String,
+}
+
+/// Challenge state for an RFC 8555 dns-01 challenge
+///
+/// See <https://www.rfc-editor.org/rfc/rfc8555#section-8.4>
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct Dns01Challenge {
+    /// A token for constructing a key authorization to complete this challenge
+    pub token: String,
+}
+
+/// Challenge state for an RFC 8737 tls-alpn-01 challenge
+///
+/// See <https://www.rfc-editor.org/rfc/rfc8737#section-3>
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct TlsAlpn01Challenge {
+    /// A token for constructing a key authorization to complete this challenge
+    pub token: String,
 }
 
 /// Status of an ACME [Challenge]
@@ -1056,11 +1156,13 @@ pub enum SigningAlgorithm {
     Other(&'static str),
 }
 
-/// The response value to use for challenge responses
+/// A key authorization computed by combining a challenge token and the base64 account thumbprint
 ///
-/// Refer to the methods below to see which encoding to use for your challenge type.
+/// The HTTP-01, DNS-01 and TLS-ALPN-01 challenge types use this as part of provisioning a
+/// challenge response. Refer to the methods below to see which encoding to use for your
+/// challenge type.
 ///
-/// <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>
+/// See <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>.
 pub struct KeyAuthorization {
     inner: String,
     digest: [u8; 32],
@@ -1203,10 +1305,13 @@ mod tests {
         }"#;
 
         let obj = serde_json::from_str::<Challenge>(CHALLENGE).unwrap();
-        assert_eq!(obj.r#type, ChallengeType::Dns01);
+        assert_eq!(obj.state.r#type(), ChallengeType::Dns01);
         assert_eq!(obj.url, "https://example.com/acme/chall/Rg5dV14Gh1Q");
         assert_eq!(obj.status, ChallengeStatus::Pending);
-        assert_eq!(obj.token, "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA");
+        assert_eq!(
+            obj.state.token(),
+            Some("evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA")
+        );
     }
 
     // https://datatracker.ietf.org/doc/html/rfc8555#section-7.6

--- a/src/types.rs
+++ b/src/types.rs
@@ -802,20 +802,6 @@ impl ChallengeState {
             Self::Unknown(r#type) => ChallengeType::Unknown(r#type.clone()),
         }
     }
-
-    /// Get the token associated with this challenge (if applicable)
-    ///
-    /// DNS-01, HTTP-01 and TLS-ALPN-01 challenge types offer a token. Other challenge types
-    /// do not rely on RFC 8555 key authorizations and will return `None`, expecting the
-    /// challenge to be satisfied with another method specific to its type.
-    pub fn token(&self) -> Option<&str> {
-        Some(match self {
-            Self::Http01(Http01Challenge { token })
-            | Self::Dns01(Dns01Challenge { token })
-            | Self::TlsAlpn01(TlsAlpn01Challenge { token }) => token,
-            Self::DeviceAttest01 | Self::Unknown { .. } => return None,
-        })
-    }
 }
 
 impl<'de> Deserialize<'de> for ChallengeState {
@@ -1308,9 +1294,13 @@ mod tests {
         assert_eq!(obj.state.r#type(), ChallengeType::Dns01);
         assert_eq!(obj.url, "https://example.com/acme/chall/Rg5dV14Gh1Q");
         assert_eq!(obj.status, ChallengeStatus::Pending);
+
+        let ChallengeState::Dns01(chall_state) = obj.state else {
+            panic!("wrong challenge state type");
+        };
         assert_eq!(
-            obj.state.token(),
-            Some("evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA")
+            chall_state.token,
+            "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA",
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,7 +18,7 @@ use x509_parser::extensions::ParsedExtension;
 #[cfg(feature = "x509-parser")]
 use x509_parser::parse_x509_certificate;
 
-use crate::{BytesResponse, Sha256};
+use crate::{BytesResponse, Key, Sha256};
 
 /// Error type for instant-acme
 #[derive(Debug, Error)]
@@ -1054,6 +1054,60 @@ pub enum SigningAlgorithm {
     /// Other algorithm not represented in the enum
     #[serde(untagged)]
     Other(&'static str),
+}
+
+/// The response value to use for challenge responses
+///
+/// Refer to the methods below to see which encoding to use for your challenge type.
+///
+/// <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>
+pub struct KeyAuthorization {
+    inner: String,
+    digest: [u8; 32],
+}
+
+impl KeyAuthorization {
+    pub(crate) fn new(token: &str, key: &Key) -> Result<Self, Error> {
+        let inner = format!(
+            "{}.{}",
+            token,
+            BASE64_URL_SAFE_NO_PAD.encode(key.thumb_sha256()?)
+        );
+
+        Ok(Self {
+            digest: key.provider.sha256.hash(inner.as_bytes()),
+            inner,
+        })
+    }
+
+    /// Get the key authorization value
+    ///
+    /// This can be used for HTTP-01 challenge responses.
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+
+    /// Get the SHA-256 digest of the key authorization
+    ///
+    /// This can be used for TLS-ALPN-01 challenge responses.
+    ///
+    /// <https://datatracker.ietf.org/doc/html/rfc8737#section-3>
+    pub fn digest(&self) -> [u8; 32] {
+        self.digest
+    }
+
+    /// Get the base64-encoded SHA256 digest of the key authorization
+    ///
+    /// This can be used for DNS-01 challenge responses.
+    pub fn dns_value(&self) -> String {
+        BASE64_URL_SAFE_NO_PAD.encode(self.digest)
+    }
+}
+
+impl fmt::Debug for KeyAuthorization {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("KeyAuthorization").finish()
+    }
 }
 
 /// Attestation payload used for device-attest-01

--- a/src/types.rs
+++ b/src/types.rs
@@ -861,6 +861,44 @@ pub struct Http01Challenge {
     pub token: String,
 }
 
+/// Challenge authorization data for an RFC 8555 http-01 challenge
+pub struct Http01ChallengeAuthorization {
+    token: String,
+    key_auth: String,
+}
+
+impl Http01ChallengeAuthorization {
+    /// The path prefix defined by RFC 8555 for HTTP-01 challenge responses.
+    pub const PREFIX: &'static str = "/.well-known/acme-challenge/";
+
+    pub(crate) fn new(token: &str, key: &Key) -> Result<Self, Error> {
+        Ok(Self {
+            token: token.to_owned(),
+            key_auth: format!(
+                "{token}.{}",
+                BASE64_URL_SAFE_NO_PAD.encode(key.thumb_sha256()?)
+            ),
+        })
+    }
+
+    /// The challenge token for this challenge authorization.
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    /// The path at which you should provision a file containing [`Self::key_authorization()`]
+    pub fn webroot_path(&self) -> String {
+        format!("{}{}", Self::PREFIX, self.token)
+    }
+
+    /// The key authorization content that should be placed in the challenge response file.
+    ///
+    /// The file should be provisioned at [`Self::webroot_path()`] in your webserver's web root.
+    pub fn key_authorization(&self) -> &str {
+        &self.key_auth
+    }
+}
+
 /// Challenge state for an RFC 8555 dns-01 challenge
 ///
 /// See <https://www.rfc-editor.org/rfc/rfc8555#section-8.4>
@@ -871,6 +909,47 @@ pub struct Dns01Challenge {
     pub token: String,
 }
 
+/// Challenge authorization data for an RFC 8555 http-01 challenge
+pub struct Dns01ChallengeAuthorization {
+    domain: String,
+    rdata: String,
+}
+
+impl Dns01ChallengeAuthorization {
+    /// The prefix added to the identifier value to form the TXT record host
+    pub const PREFIX: &'static str = "_acme-challenge.";
+
+    pub(crate) fn new(identifier: &Identifier, token: &str, key: &Key) -> Result<Self, Error> {
+        let Identifier::Dns(domain) = identifier else {
+            unreachable!("DNS-01 only supports domain identifiers");
+        };
+
+        let key_auth = format!(
+            "{token}.{}",
+            BASE64_URL_SAFE_NO_PAD.encode(key.thumb_sha256()?)
+        );
+
+        Ok(Self {
+            domain: domain.clone(),
+            rdata: BASE64_URL_SAFE_NO_PAD.encode(key.provider.sha256.hash(key_auth.as_bytes())),
+        })
+    }
+
+    /// Fully qualified hostname for the challenge response TXT record to be provisioned
+    ///
+    /// Includes a trailing dot.
+    pub fn host(&self) -> String {
+        format!("{}{}.", Self::PREFIX, self.domain)
+    }
+
+    /// The TXT record RDATA to provision for [`Self::host()`]
+    ///
+    /// This is the base64-encoded SHA256 digest of the challenge key authorization.
+    pub fn rdata(&self) -> &str {
+        &self.rdata
+    }
+}
+
 /// Challenge state for an RFC 8737 tls-alpn-01 challenge
 ///
 /// See <https://www.rfc-editor.org/rfc/rfc8737#section-3>
@@ -879,6 +958,44 @@ pub struct Dns01Challenge {
 pub struct TlsAlpn01Challenge {
     /// A token for constructing a key authorization to complete this challenge
     pub token: String,
+}
+
+/// Challenge authorization data for an RFC 8737 tls-alpn-01 challenge
+pub struct TlsAlpn01ChallengeAuthorization {
+    key_auth: String,
+    extension_value: Vec<u8>,
+}
+
+impl TlsAlpn01ChallengeAuthorization {
+    pub(crate) fn new(token: &str, key: &Key) -> Result<Self, Error> {
+        let key_auth = format!(
+            "{token}.{}",
+            BASE64_URL_SAFE_NO_PAD.encode(key.thumb_sha256()?)
+        );
+        Ok(Self {
+            extension_value: key.provider.sha256.hash(key_auth.as_bytes()).to_vec(),
+            key_auth,
+        })
+    }
+
+    /// The unhashed key authorization string
+    ///
+    /// Typically, you would prefer using [`Self::extension_value`] to construct
+    /// a DER encoded id-pe-acmeIdentifier extension.
+    ///
+    /// This API may be useful when using a higher-level TLS-ALPN-01 certificate generation
+    /// API that expects the RFC-8555 §8.1 key authorization string as input.
+    pub fn key_authorization(&self) -> &str {
+        &self.key_auth
+    }
+
+    /// The SHA-256 digest of the RFC-8555 §8.1 key authorization string
+    ///
+    /// This can be used to construct a DER encoded id-pe-acmeIdentifier extension
+    /// for embedding in a provisioned TLS-ALPN-01 challenge response certificate.
+    pub fn extension_value(&self) -> &[u8] {
+        &self.extension_value
+    }
 }
 
 /// Status of an ACME [Challenge]
@@ -1140,62 +1257,6 @@ pub enum SigningAlgorithm {
     /// Other algorithm not represented in the enum
     #[serde(untagged)]
     Other(&'static str),
-}
-
-/// A key authorization computed by combining a challenge token and the base64 account thumbprint
-///
-/// The HTTP-01, DNS-01 and TLS-ALPN-01 challenge types use this as part of provisioning a
-/// challenge response. Refer to the methods below to see which encoding to use for your
-/// challenge type.
-///
-/// See <https://datatracker.ietf.org/doc/html/rfc8555#section-8.1>.
-pub struct KeyAuthorization {
-    inner: String,
-    digest: [u8; 32],
-}
-
-impl KeyAuthorization {
-    pub(crate) fn new(token: &str, key: &Key) -> Result<Self, Error> {
-        let inner = format!(
-            "{}.{}",
-            token,
-            BASE64_URL_SAFE_NO_PAD.encode(key.thumb_sha256()?)
-        );
-
-        Ok(Self {
-            digest: key.provider.sha256.hash(inner.as_bytes()),
-            inner,
-        })
-    }
-
-    /// Get the key authorization value
-    ///
-    /// This can be used for HTTP-01 challenge responses.
-    pub fn as_str(&self) -> &str {
-        &self.inner
-    }
-
-    /// Get the SHA-256 digest of the key authorization
-    ///
-    /// This can be used for TLS-ALPN-01 challenge responses.
-    ///
-    /// <https://datatracker.ietf.org/doc/html/rfc8737#section-3>
-    pub fn digest(&self) -> [u8; 32] {
-        self.digest
-    }
-
-    /// Get the base64-encoded SHA256 digest of the key authorization
-    ///
-    /// This can be used for DNS-01 challenge responses.
-    pub fn dns_value(&self) -> String {
-        BASE64_URL_SAFE_NO_PAD.encode(self.digest)
-    }
-}
-
-impl fmt::Debug for KeyAuthorization {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("KeyAuthorization").finish()
-    }
 }
 
 /// Attestation payload used for device-attest-01

--- a/src/types.rs
+++ b/src/types.rs
@@ -397,26 +397,6 @@ pub enum OctetKeyCurve {
     X448,
 }
 
-/// An ACME challenge as described in RFC 8555 (section 7.1.5)
-///
-/// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.5>
-#[derive(Debug, Deserialize)]
-pub struct Challenge {
-    /// Type of challenge
-    pub r#type: ChallengeType,
-    /// Challenge identifier
-    pub url: String,
-    /// Token for this challenge
-    ///
-    /// Unknown `ChallengeType` instances may omit this field, leaving it empty.
-    #[serde(default)]
-    pub token: String,
-    /// Current status
-    pub status: ChallengeStatus,
-    /// Potential error state
-    pub error: Option<Problem>,
-}
-
 /// Contents of an ACME order as described in RFC 8555 (section 7.1.3)
 ///
 /// The order identity will usually be represented by an [Order](crate::Order).
@@ -713,19 +693,6 @@ impl AuthorizationState {
     }
 }
 
-/// Status for an [`AuthorizationState`]
-#[allow(missing_docs)]
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub enum AuthorizationStatus {
-    Pending,
-    Valid,
-    Invalid,
-    Revoked,
-    Expired,
-    Deactivated,
-}
-
 /// Represent an identifier in an ACME [Order](crate::Order)
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -790,6 +757,26 @@ impl fmt::Display for AuthorizedIdentifier<'_> {
     }
 }
 
+/// An ACME challenge as described in RFC 8555 (section 7.1.5)
+///
+/// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.5>
+#[derive(Debug, Deserialize)]
+pub struct Challenge {
+    /// Type of challenge
+    pub r#type: ChallengeType,
+    /// Challenge identifier
+    pub url: String,
+    /// Token for this challenge
+    ///
+    /// Unknown `ChallengeType` instances may omit this field, leaving it empty.
+    #[serde(default)]
+    pub token: String,
+    /// Current status
+    pub status: ChallengeStatus,
+    /// Potential error state
+    pub error: Option<Problem>,
+}
+
 /// The challenge type
 #[allow(missing_docs)]
 #[non_exhaustive]
@@ -817,6 +804,19 @@ pub enum ChallengeStatus {
     Processing,
     Valid,
     Invalid,
+}
+
+/// Status for an [`AuthorizationState`]
+#[allow(missing_docs)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum AuthorizationStatus {
+    Pending,
+    Valid,
+    Invalid,
+    Revoked,
+    Expired,
+    Deactivated,
 }
 
 /// Status of an [Order](crate::Order)

--- a/src/types.rs
+++ b/src/types.rs
@@ -397,26 +397,6 @@ pub enum OctetKeyCurve {
     X448,
 }
 
-/// An ACME challenge as described in RFC 8555 (section 7.1.5)
-///
-/// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.5>
-#[derive(Debug, Deserialize)]
-pub struct Challenge {
-    /// Type of challenge
-    pub r#type: ChallengeType,
-    /// Challenge identifier
-    pub url: String,
-    /// Token for this challenge
-    ///
-    /// Unknown `ChallengeType` instances may omit this field, leaving it empty.
-    #[serde(default)]
-    pub token: String,
-    /// Current status
-    pub status: ChallengeStatus,
-    /// Potential error state
-    pub error: Option<Problem>,
-}
-
 /// Contents of an ACME order as described in RFC 8555 (section 7.1.3)
 ///
 /// The order identity will usually be represented by an [Order](crate::Order).
@@ -762,19 +742,6 @@ impl AuthorizationState {
     }
 }
 
-/// Status for an [`AuthorizationState`]
-#[allow(missing_docs)]
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub enum AuthorizationStatus {
-    Pending,
-    Valid,
-    Invalid,
-    Revoked,
-    Expired,
-    Deactivated,
-}
-
 /// Represent an identifier in an ACME [Order](crate::Order)
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -839,6 +806,26 @@ impl fmt::Display for AuthorizedIdentifier<'_> {
     }
 }
 
+/// An ACME challenge as described in RFC 8555 (section 7.1.5)
+///
+/// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.5>
+#[derive(Debug, Deserialize)]
+pub struct Challenge {
+    /// Type of challenge
+    pub r#type: ChallengeType,
+    /// Challenge identifier
+    pub url: String,
+    /// Token for this challenge
+    ///
+    /// Unknown `ChallengeType` instances may omit this field, leaving it empty.
+    #[serde(default)]
+    pub token: String,
+    /// Current status
+    pub status: ChallengeStatus,
+    /// Potential error state
+    pub error: Option<Problem>,
+}
+
 /// The challenge type
 #[allow(missing_docs)]
 #[non_exhaustive]
@@ -866,6 +853,19 @@ pub enum ChallengeStatus {
     Processing,
     Valid,
     Invalid,
+}
+
+/// Status for an [`AuthorizationState`]
+#[allow(missing_docs)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum AuthorizationStatus {
+    Pending,
+    Valid,
+    Invalid,
+    Revoked,
+    Expired,
+    Deactivated,
 }
 
 /// Status of an [Order](crate::Order)

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,6 +18,7 @@ use x509_parser::extensions::ParsedExtension;
 #[cfg(feature = "x509-parser")]
 use x509_parser::parse_x509_certificate;
 
+use crate::challenges::Challenge;
 use crate::{BytesResponse, Sha256};
 
 /// Error type for instant-acme
@@ -806,55 +807,6 @@ impl fmt::Display for AuthorizedIdentifier<'_> {
     }
 }
 
-/// An ACME challenge as described in RFC 8555 (section 7.1.5)
-///
-/// <https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.5>
-#[derive(Debug, Deserialize)]
-pub struct Challenge {
-    /// Type of challenge
-    pub r#type: ChallengeType,
-    /// Challenge identifier
-    pub url: String,
-    /// Token for this challenge
-    ///
-    /// Unknown `ChallengeType` instances may omit this field, leaving it empty.
-    #[serde(default)]
-    pub token: String,
-    /// Current status
-    pub status: ChallengeStatus,
-    /// Potential error state
-    pub error: Option<Problem>,
-}
-
-/// The challenge type
-#[allow(missing_docs)]
-#[non_exhaustive]
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
-pub enum ChallengeType {
-    #[serde(rename = "http-01")]
-    Http01,
-    #[serde(rename = "dns-01")]
-    Dns01,
-    #[serde(rename = "tls-alpn-01")]
-    TlsAlpn01,
-    /// Note: Device attestation support is experimental
-    #[serde(rename = "device-attest-01")]
-    DeviceAttest01,
-    #[serde(untagged)]
-    Unknown(String),
-}
-
-/// Status of an ACME [Challenge]
-#[allow(missing_docs)]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub enum ChallengeStatus {
-    Pending,
-    Processing,
-    Valid,
-    Invalid,
-}
-
 /// Status for an [`AuthorizationState`]
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -1105,14 +1057,6 @@ pub enum SigningAlgorithm {
     Other(&'static str),
 }
 
-/// Attestation payload used for device-attest-01
-///
-/// See <https://datatracker.ietf.org/doc/draft-acme-device-attest/> for details.
-pub struct DeviceAttestation<'a> {
-    /// CBOR encoded attestation payload
-    pub att_obj: Cow<'a, [u8]>,
-}
-
 #[derive(Debug, Serialize)]
 pub(crate) struct Empty {}
 
@@ -1198,23 +1142,6 @@ mod tests {
         assert_eq!(obj.status, AuthorizationStatus::Valid);
         assert_eq!(obj.identifier, Identifier::Dns("www.example.org".into()));
         assert_eq!(obj.challenges.len(), 1);
-    }
-
-    // https://datatracker.ietf.org/doc/html/rfc8555#section-8.4
-    #[test]
-    fn challenge() {
-        const CHALLENGE: &str = r#"{
-          "type": "dns-01",
-          "url": "https://example.com/acme/chall/Rg5dV14Gh1Q",
-          "status": "pending",
-          "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA"
-        }"#;
-
-        let obj = serde_json::from_str::<Challenge>(CHALLENGE).unwrap();
-        assert_eq!(obj.r#type, ChallengeType::Dns01);
-        assert_eq!(obj.url, "https://example.com/acme/chall/Rg5dV14Gh1Q");
-        assert_eq!(obj.status, ChallengeStatus::Pending);
-        assert_eq!(obj.token, "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA");
     }
 
     // https://datatracker.ietf.org/doc/html/rfc8555#section-7.6

--- a/src/types.rs
+++ b/src/types.rs
@@ -782,7 +782,7 @@ impl Identifier {
 
 /// An [`Identifier`] which knows its `wildcard` context
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct AuthorizedIdentifier<'a> {
     /// The source identifier, missing any wildcard context
     pub identifier: &'a Identifier,

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -769,13 +769,10 @@ impl AuthorizationMethod for Http01 {
     ) -> Result<(), Box<dyn StdError>> {
         let mut http_chall = authz.http01().expect("missing HTTP-01 challenge");
         let token = http_chall.token();
-        let key_auth = http_chall.key_authorization()?;
+        let auth_resp = http_chall.authorization()?;
+        let key_auth = auth_resp.key_authorization();
 
-        debug!(
-            token,
-            key_auth = key_auth.as_str(),
-            "provisioning HTTP-01 response",
-        );
+        debug!(token, key_auth, "provisioning HTTP-01 response",);
 
         #[derive(Serialize)]
         struct AddHttp01Request<'a> {
@@ -785,7 +782,7 @@ impl AuthorizationMethod for Http01 {
 
         let body = serde_json::to_vec(&AddHttp01Request {
             token,
-            content: key_auth.as_str(),
+            content: key_auth,
         })?;
         let url = format!("http://[::1]:{challtestsrv_port}/add-http01");
         client
@@ -813,15 +810,11 @@ impl AuthorizationMethod for Dns01 {
         challtestsrv_port: u16,
     ) -> Result<(), Box<dyn StdError>> {
         let mut dns_chall = authz.dns01().expect("missing DNS-01 challenge");
-        let key_auth = dns_chall.key_authorization()?.dns_value();
-        let identifier = dns_chall.identifier();
+        let auth_resp = dns_chall.authorization()?;
 
-        let Identifier::Dns(domain) = identifier.identifier else {
-            unreachable!("unsupported identifier {identifier:?}");
-        };
-
-        let host = format!("_acme-challenge.{domain}.");
-        debug!(host, key_auth, "provisioning DNS-01 response");
+        let host = auth_resp.host();
+        let rdata = auth_resp.rdata();
+        debug!(host, rdata, "provisioning DNS-01 response");
 
         #[derive(Serialize)]
         struct AddDns01Request {
@@ -831,7 +824,7 @@ impl AuthorizationMethod for Dns01 {
 
         let body = serde_json::to_vec(&AddDns01Request {
             host,
-            value: key_auth,
+            value: rdata.to_owned(),
         })?;
         let url = format!("http://[::1]:{challtestsrv_port}/set-txt");
         client
@@ -859,12 +852,15 @@ impl AuthorizationMethod for Alpn01 {
         challtestsrv_port: u16,
     ) -> Result<(), Box<dyn StdError>> {
         let mut tls_chall = authz.tls_alpn01().expect("missing TLS-ALPN-01 challenge");
-        let key_auth = tls_chall.key_authorization()?;
+        let auth_resp = tls_chall.authorization()?;
+        // Note: pebble-challtestsrv wants to hash the key auth itself, so we
+        // don't use `auth_resp.extension_value()` here.
+        let key_auth = auth_resp.key_authorization();
         let identifier = tls_chall.identifier();
 
         debug!(
             %identifier,
-            key_auth = key_auth.as_str(),
+            key_auth,
             "provisioning TLS-ALPN-01 response",
         );
 
@@ -876,9 +872,7 @@ impl AuthorizationMethod for Alpn01 {
 
         let body = serde_json::to_vec(&AddAlpn01Request {
             host: identifier.to_string(),
-            // Note: pebble-challtestsrv wants to hash the key auth itself, so we
-            // don't use key_auth.digest() here.
-            content: key_auth.as_str(),
+            content: key_auth,
         })?;
         let url = format!("http://[::1]:{}/add-tlsalpn01", challtestsrv_port);
         client

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 use std::error::Error as StdError;
+use std::future::Future;
 use std::io::{self, Read};
 use std::net::IpAddr;
 use std::path::Path;
@@ -25,9 +26,8 @@ use hyper_util::client::legacy::Client as HyperClient;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
 use instant_acme::{
-    Account, AuthorizationStatus, BodyWrapper, ChallengeHandle, ChallengeType, CryptoProvider,
-    Error, ExternalAccountKey, Identifier, Key, KeyAuthorization, NewAccount, NewOrder, Order,
-    OrderStatus, RetryPolicy,
+    Account, AuthorizationHandle, AuthorizationStatus, BodyWrapper, CryptoProvider, Error,
+    ExternalAccountKey, Identifier, Key, NewAccount, NewOrder, Order, OrderStatus, RetryPolicy,
 };
 #[cfg(all(feature = "time", feature = "x509-parser"))]
 use instant_acme::{CertificateIdentifier, RevocationRequest};
@@ -647,15 +647,7 @@ impl Environment {
                 _ => unreachable!("unexpected authz state: {:?}", authz.status),
             }
 
-            let mut challenge = authz
-                .challenge(A::TYPE)
-                .ok_or_else(|| format!("no {:?} challenge found", A::TYPE))?;
-
-            let key_authz = challenge.key_authorization()?.unwrap();
-            self.request_challenge::<A>(&challenge, &key_authz).await?;
-
-            debug!(challenge_url = challenge.url, "marking challenge ready");
-            challenge.set_ready().await?;
+            A::handle_challenge(&mut authz, &self.client, self.config.challtestsrv_port).await?;
         }
 
         // Poll until the order is ready.
@@ -758,25 +750,6 @@ impl Environment {
         assert_eq!(roots.len(), 1);
         Ok(roots)
     }
-
-    async fn request_challenge<'a, A: AuthorizationMethod>(
-        &self,
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &KeyAuthorization,
-    ) -> Result<(), Box<dyn StdError>> {
-        let url = format!("http://[::1]:{}/{}", self.config.challtestsrv_port, A::PATH);
-        let body = serde_json::to_vec(&A::authz_request(challenge, key_auth))?;
-        self.client
-            .request(
-                Request::builder()
-                    .method(Method::POST)
-                    .uri(url)
-                    .header(CONTENT_TYPE, "application/json")
-                    .body(BodyWrapper::from(body))?,
-            )
-            .await?;
-        Ok(())
-    }
 }
 
 fn dns_identifiers(dns_names: impl IntoIterator<Item = impl ToString>) -> Vec<Identifier> {
@@ -789,12 +762,17 @@ fn dns_identifiers(dns_names: impl IntoIterator<Item = impl ToString>) -> Vec<Id
 struct Http01;
 
 impl AuthorizationMethod for Http01 {
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a {
+    async fn handle_challenge<'a>(
+        authz: &'a mut AuthorizationHandle<'a>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> Result<(), Box<dyn StdError>> {
+        let mut http_chall = authz.http01().expect("missing HTTP-01 challenge");
+        let token = http_chall.token();
+        let key_auth = http_chall.key_authorization()?;
+
         debug!(
-            token = challenge.state.token(),
+            token,
             key_auth = key_auth.as_str(),
             "provisioning HTTP-01 response",
         );
@@ -805,31 +783,45 @@ impl AuthorizationMethod for Http01 {
             content: &'a str,
         }
 
-        AddHttp01Request {
-            token: challenge.state.token().unwrap(),
+        let body = serde_json::to_vec(&AddHttp01Request {
+            token,
             content: key_auth.as_str(),
-        }
-    }
+        })?;
+        let url = format!("http://[::1]:{challtestsrv_port}/add-http01");
+        client
+            .request(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(url)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(BodyWrapper::from(body))?,
+            )
+            .await?;
 
-    const PATH: &str = "add-http01";
-    const TYPE: ChallengeType = ChallengeType::Http01;
+        debug!("marking challenge ready");
+        http_chall.set_ready().await?;
+        Ok(())
+    }
 }
 
 struct Dns01;
 
 impl AuthorizationMethod for Dns01 {
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'_>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a {
-        let identifier = challenge.identifier();
+    async fn handle_challenge<'a>(
+        authz: &'a mut AuthorizationHandle<'a>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> Result<(), Box<dyn StdError>> {
+        let mut dns_chall = authz.dns01().expect("missing DNS-01 challenge");
+        let key_auth = dns_chall.key_authorization()?.dns_value();
+        let identifier = dns_chall.identifier();
+
         let Identifier::Dns(domain) = identifier.identifier else {
             unreachable!("unsupported identifier {identifier:?}");
         };
 
         let host = format!("_acme-challenge.{domain}.");
-        let value = key_auth.dns_value();
-        debug!(host, value, "provisioning DNS-01 response");
+        debug!(host, key_auth, "provisioning DNS-01 response");
 
         #[derive(Serialize)]
         struct AddDns01Request {
@@ -837,22 +829,41 @@ impl AuthorizationMethod for Dns01 {
             value: String,
         }
 
-        AddDns01Request { host, value }
-    }
+        let body = serde_json::to_vec(&AddDns01Request {
+            host,
+            value: key_auth,
+        })?;
+        let url = format!("http://[::1]:{challtestsrv_port}/set-txt");
+        client
+            .request(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(url)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(BodyWrapper::from(body))?,
+            )
+            .await?;
 
-    const PATH: &str = "set-txt";
-    const TYPE: ChallengeType = ChallengeType::Dns01;
+        debug!("marking challenge ready");
+        dns_chall.set_ready().await?;
+        Ok(())
+    }
 }
 
 struct Alpn01;
 
 impl AuthorizationMethod for Alpn01 {
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a {
+    async fn handle_challenge<'a>(
+        authz: &'a mut AuthorizationHandle<'a>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> Result<(), Box<dyn StdError>> {
+        let mut tls_chall = authz.tls_alpn01().expect("missing TLS-ALPN-01 challenge");
+        let key_auth = tls_chall.key_authorization()?;
+        let identifier = tls_chall.identifier();
+
         debug!(
-            identifier = %challenge.identifier(),
+            %identifier,
             key_auth = key_auth.as_str(),
             "provisioning TLS-ALPN-01 response",
         );
@@ -863,28 +874,40 @@ impl AuthorizationMethod for Alpn01 {
             content: &'a str,
         }
 
-        AddAlpn01Request {
-            host: challenge.identifier().to_string(),
+        let body = serde_json::to_vec(&AddAlpn01Request {
+            host: identifier.to_string(),
             // Note: pebble-challtestsrv wants to hash the key auth itself, so we
             // don't use key_auth.digest() here.
             content: key_auth.as_str(),
-        }
-    }
+        })?;
+        let url = format!("http://[::1]:{}/add-tlsalpn01", challtestsrv_port);
+        client
+            .request(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(url)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(BodyWrapper::from(body))?,
+            )
+            .await?;
 
-    const PATH: &str = "add-tlsalpn01";
-    const TYPE: ChallengeType = ChallengeType::TlsAlpn01;
+        debug!("marking challenge ready");
+        tls_chall.set_ready().await?;
+        Ok(())
+    }
 }
 
-/// A trait for something able to provision a challenge response with an external system
+/// A trait for something able to handle an authorization challenge
+///
+/// Usually this will be accomplished by provisioning a response with an external system,
+/// and then indicating the challenge is ready for validation by the ACME server.
 trait AuthorizationMethod {
-    /// Provision a challenge response for the given identifier, challenge, and key auth.
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a;
-
-    const PATH: &str;
-    const TYPE: ChallengeType;
+    /// Handle the challenge for this authorization method
+    fn handle_challenge<'a>(
+        authz: &'a mut AuthorizationHandle<'a>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> impl Future<Output = Result<(), Box<dyn StdError>>> + Send;
 }
 
 /// Wait for the server at the given address to be ready

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -651,7 +651,7 @@ impl Environment {
                 .challenge(A::TYPE)
                 .ok_or_else(|| format!("no {:?} challenge found", A::TYPE))?;
 
-            let key_authz = challenge.key_authorization()?;
+            let key_authz = challenge.key_authorization()?.unwrap();
             self.request_challenge::<A>(&challenge, &key_authz).await?;
 
             debug!(challenge_url = challenge.url, "marking challenge ready");
@@ -794,7 +794,7 @@ impl AuthorizationMethod for Http01 {
         key_auth: &'a KeyAuthorization,
     ) -> impl Serialize + 'a {
         debug!(
-            token = challenge.token,
+            token = challenge.state.token(),
             key_auth = key_auth.as_str(),
             "provisioning HTTP-01 response",
         );
@@ -806,7 +806,7 @@ impl AuthorizationMethod for Http01 {
         }
 
         AddHttp01Request {
-            token: &challenge.token,
+            token: challenge.state.token().unwrap(),
             content: key_auth.as_str(),
         }
     }

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 use std::error::Error as StdError;
+use std::future::Future;
 use std::io::{self, Read};
 use std::net::IpAddr;
 use std::path::Path;
@@ -25,9 +26,8 @@ use hyper_util::client::legacy::Client as HyperClient;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
 use instant_acme::{
-    Account, AuthorizationStatus, BodyWrapper, ChallengeHandle, ChallengeType, CryptoProvider,
-    Error, ExternalAccountKey, Identifier, Key, KeyAuthorization, NewAccount, NewOrder, Order,
-    OrderStatus, RetryPolicy,
+    Account, AuthorizationHandle, AuthorizationStatus, BodyWrapper, CryptoProvider, Error,
+    ExternalAccountKey, Identifier, Key, NewAccount, NewOrder, Order, OrderStatus, RetryPolicy,
 };
 #[cfg(all(feature = "time", feature = "x509-parser"))]
 use instant_acme::{CertificateIdentifier, RevocationRequest};
@@ -689,15 +689,7 @@ impl Environment {
                 _ => unreachable!("unexpected authz state: {:?}", authz.status),
             }
 
-            let mut challenge = authz
-                .challenge(A::TYPE)
-                .ok_or_else(|| format!("no {:?} challenge found", A::TYPE))?;
-
-            let key_authz = challenge.key_authorization()?.unwrap();
-            self.request_challenge::<A>(&challenge, &key_authz).await?;
-
-            debug!(challenge_url = challenge.url, "marking challenge ready");
-            challenge.set_ready().await?;
+            A::handle_challenge(&mut authz, &self.client, self.config.challtestsrv_port).await?;
         }
 
         // Poll until the order is ready.
@@ -800,25 +792,6 @@ impl Environment {
         assert_eq!(roots.len(), 1);
         Ok(roots)
     }
-
-    async fn request_challenge<'a, A: AuthorizationMethod>(
-        &self,
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &KeyAuthorization,
-    ) -> Result<(), Box<dyn StdError>> {
-        let url = format!("http://[::1]:{}/{}", self.config.challtestsrv_port, A::PATH);
-        let body = serde_json::to_vec(&A::authz_request(challenge, key_auth))?;
-        self.client
-            .request(
-                Request::builder()
-                    .method(Method::POST)
-                    .uri(url)
-                    .header(CONTENT_TYPE, "application/json")
-                    .body(BodyWrapper::from(body))?,
-            )
-            .await?;
-        Ok(())
-    }
 }
 
 fn dns_identifiers(dns_names: impl IntoIterator<Item = impl ToString>) -> Vec<Identifier> {
@@ -831,12 +804,17 @@ fn dns_identifiers(dns_names: impl IntoIterator<Item = impl ToString>) -> Vec<Id
 struct Http01;
 
 impl AuthorizationMethod for Http01 {
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a {
+    async fn handle_challenge(
+        authz: &mut AuthorizationHandle<'_>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> Result<(), Box<dyn StdError>> {
+        let mut http_chall = authz.http01().expect("missing HTTP-01 challenge");
+        let token = http_chall.token();
+        let key_auth = http_chall.key_authorization()?;
+
         debug!(
-            token = challenge.state.token(),
+            token,
             key_auth = key_auth.as_str(),
             "provisioning HTTP-01 response",
         );
@@ -847,31 +825,45 @@ impl AuthorizationMethod for Http01 {
             content: &'a str,
         }
 
-        AddHttp01Request {
-            token: challenge.state.token().unwrap(),
+        let body = serde_json::to_vec(&AddHttp01Request {
+            token,
             content: key_auth.as_str(),
-        }
-    }
+        })?;
+        let url = format!("http://[::1]:{challtestsrv_port}/add-http01");
+        client
+            .request(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(url)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(BodyWrapper::from(body))?,
+            )
+            .await?;
 
-    const PATH: &str = "add-http01";
-    const TYPE: ChallengeType = ChallengeType::Http01;
+        debug!("marking challenge ready");
+        http_chall.set_ready().await?;
+        Ok(())
+    }
 }
 
 struct Dns01;
 
 impl AuthorizationMethod for Dns01 {
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'_>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a {
-        let identifier = challenge.identifier();
+    async fn handle_challenge(
+        authz: &mut AuthorizationHandle<'_>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> Result<(), Box<dyn StdError>> {
+        let mut dns_chall = authz.dns01().expect("missing DNS-01 challenge");
+        let key_auth = dns_chall.key_authorization()?.dns_value();
+        let identifier = dns_chall.identifier();
+
         let Identifier::Dns(domain) = identifier.identifier else {
             unreachable!("unsupported identifier {identifier:?}");
         };
 
         let host = format!("_acme-challenge.{domain}.");
-        let value = key_auth.dns_value();
-        debug!(host, value, "provisioning DNS-01 response");
+        debug!(host, key_auth, "provisioning DNS-01 response");
 
         #[derive(Serialize)]
         struct AddDns01Request {
@@ -879,22 +871,41 @@ impl AuthorizationMethod for Dns01 {
             value: String,
         }
 
-        AddDns01Request { host, value }
-    }
+        let body = serde_json::to_vec(&AddDns01Request {
+            host,
+            value: key_auth,
+        })?;
+        let url = format!("http://[::1]:{challtestsrv_port}/set-txt");
+        client
+            .request(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(url)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(BodyWrapper::from(body))?,
+            )
+            .await?;
 
-    const PATH: &str = "set-txt";
-    const TYPE: ChallengeType = ChallengeType::Dns01;
+        debug!("marking challenge ready");
+        dns_chall.set_ready().await?;
+        Ok(())
+    }
 }
 
 struct Alpn01;
 
 impl AuthorizationMethod for Alpn01 {
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a {
+    async fn handle_challenge(
+        authz: &mut AuthorizationHandle<'_>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> Result<(), Box<dyn StdError>> {
+        let mut tls_chall = authz.tls_alpn01().expect("missing TLS-ALPN-01 challenge");
+        let key_auth = tls_chall.key_authorization()?;
+        let identifier = tls_chall.identifier();
+
         debug!(
-            identifier = %challenge.identifier(),
+            %identifier,
             key_auth = key_auth.as_str(),
             "provisioning TLS-ALPN-01 response",
         );
@@ -905,28 +916,40 @@ impl AuthorizationMethod for Alpn01 {
             content: &'a str,
         }
 
-        AddAlpn01Request {
-            host: challenge.identifier().to_string(),
+        let body = serde_json::to_vec(&AddAlpn01Request {
+            host: identifier.to_string(),
             // Note: pebble-challtestsrv wants to hash the key auth itself, so we
             // don't use key_auth.digest() here.
             content: key_auth.as_str(),
-        }
-    }
+        })?;
+        let url = format!("http://[::1]:{}/add-tlsalpn01", challtestsrv_port);
+        client
+            .request(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(url)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(BodyWrapper::from(body))?,
+            )
+            .await?;
 
-    const PATH: &str = "add-tlsalpn01";
-    const TYPE: ChallengeType = ChallengeType::TlsAlpn01;
+        debug!("marking challenge ready");
+        tls_chall.set_ready().await?;
+        Ok(())
+    }
 }
 
-/// A trait for something able to provision a challenge response with an external system
+/// A trait for something able to handle an authorization challenge
+///
+/// Usually this will be accomplished by provisioning a response with an external system,
+/// and then indicating the challenge is ready for validation by the ACME server.
 trait AuthorizationMethod {
-    /// Provision a challenge response for the given identifier, challenge, and key auth.
-    fn authz_request<'a>(
-        challenge: &'a ChallengeHandle<'a>,
-        key_auth: &'a KeyAuthorization,
-    ) -> impl Serialize + 'a;
-
-    const PATH: &str;
-    const TYPE: ChallengeType;
+    /// Handle the challenge for this authorization method
+    fn handle_challenge(
+        authz: &mut AuthorizationHandle<'_>,
+        client: &HyperClient<hyper_rustls::HttpsConnector<HttpConnector>, BodyWrapper<Bytes>>,
+        challtestsrv_port: u16,
+    ) -> impl Future<Output = Result<(), Box<dyn StdError>>> + Send;
 }
 
 /// Wait for the server at the given address to be ready

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -811,13 +811,10 @@ impl AuthorizationMethod for Http01 {
     ) -> Result<(), Box<dyn StdError>> {
         let mut http_chall = authz.http01().expect("missing HTTP-01 challenge");
         let token = http_chall.token();
-        let key_auth = http_chall.key_authorization()?;
+        let response = http_chall.response();
+        let key_auth = response.key_authorization();
 
-        debug!(
-            token,
-            key_auth = key_auth.as_str(),
-            "provisioning HTTP-01 response",
-        );
+        debug!(token, key_auth, "provisioning HTTP-01 response",);
 
         #[derive(Serialize)]
         struct AddHttp01Request<'a> {
@@ -827,7 +824,7 @@ impl AuthorizationMethod for Http01 {
 
         let body = serde_json::to_vec(&AddHttp01Request {
             token,
-            content: key_auth.as_str(),
+            content: key_auth,
         })?;
         let url = format!("http://[::1]:{challtestsrv_port}/add-http01");
         client
@@ -855,26 +852,19 @@ impl AuthorizationMethod for Dns01 {
         challtestsrv_port: u16,
     ) -> Result<(), Box<dyn StdError>> {
         let mut dns_chall = authz.dns01().expect("missing DNS-01 challenge");
-        let key_auth = dns_chall.key_authorization()?.dns_value();
-        let identifier = dns_chall.identifier();
+        let response = dns_chall.response();
 
-        let Identifier::Dns(domain) = identifier.identifier else {
-            unreachable!("unsupported identifier {identifier:?}");
-        };
-
-        let host = format!("_acme-challenge.{domain}.");
-        debug!(host, key_auth, "provisioning DNS-01 response");
+        let host = response.host();
+        let rdata = response.rdata();
+        debug!(host, rdata, "provisioning DNS-01 response");
 
         #[derive(Serialize)]
-        struct AddDns01Request {
-            host: String,
-            value: String,
+        struct AddDns01Request<'a> {
+            host: &'a str,
+            value: &'a str,
         }
 
-        let body = serde_json::to_vec(&AddDns01Request {
-            host,
-            value: key_auth,
-        })?;
+        let body = serde_json::to_vec(&AddDns01Request { host, value: rdata })?;
         let url = format!("http://[::1]:{challtestsrv_port}/set-txt");
         client
             .request(
@@ -901,12 +891,15 @@ impl AuthorizationMethod for Alpn01 {
         challtestsrv_port: u16,
     ) -> Result<(), Box<dyn StdError>> {
         let mut tls_chall = authz.tls_alpn01().expect("missing TLS-ALPN-01 challenge");
-        let key_auth = tls_chall.key_authorization()?;
+        let response = tls_chall.response();
+        // Note: pebble-challtestsrv wants to hash the key auth itself, so we
+        // don't use `response.extension_value()` here.
+        let key_auth = response.key_authorization();
         let identifier = tls_chall.identifier();
 
         debug!(
             %identifier,
-            key_auth = key_auth.as_str(),
+            key_auth,
             "provisioning TLS-ALPN-01 response",
         );
 
@@ -918,9 +911,7 @@ impl AuthorizationMethod for Alpn01 {
 
         let body = serde_json::to_vec(&AddAlpn01Request {
             host: identifier.to_string(),
-            // Note: pebble-challtestsrv wants to hash the key auth itself, so we
-            // don't use key_auth.digest() here.
-            content: key_auth.as_str(),
+            content: key_auth,
         })?;
         let url = format!("http://[::1]:{}/add-tlsalpn01", challtestsrv_port);
         client

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -693,7 +693,7 @@ impl Environment {
                 .challenge(A::TYPE)
                 .ok_or_else(|| format!("no {:?} challenge found", A::TYPE))?;
 
-            let key_authz = challenge.key_authorization()?;
+            let key_authz = challenge.key_authorization()?.unwrap();
             self.request_challenge::<A>(&challenge, &key_authz).await?;
 
             debug!(challenge_url = challenge.url, "marking challenge ready");
@@ -836,7 +836,7 @@ impl AuthorizationMethod for Http01 {
         key_auth: &'a KeyAuthorization,
     ) -> impl Serialize + 'a {
         debug!(
-            token = challenge.token,
+            token = challenge.state.token(),
             key_auth = key_auth.as_str(),
             "provisioning HTTP-01 response",
         );
@@ -848,7 +848,7 @@ impl AuthorizationMethod for Http01 {
         }
 
         AddHttp01Request {
-            token: &challenge.token,
+            token: challenge.state.token().unwrap(),
             content: key_auth.as_str(),
         }
     }


### PR DESCRIPTION
Extracts the portions of https://github.com/djc/instant-acme/pull/279 that are not specific to `dns-persist-01`.

The key motivation of the design I landed on is that while it's convenient to try and abstract away authorization challenge response across multiple challenge types, in reality there are a lot of challenge type specific details one has to contend with even when using challenges that all derive the key auth from the token (e.g. the format of the key authorization: should it be the raw string? a SHA256 digest? the base64 of that digest?). 

Further, the new challenge types (`dns-persist-01`, `device-attest-01`) don't have as much in common with the "legacy" challenge types and so we should be using the type system more to differentiate the challenge contexts. This also lets us tighten up what challenges are used for which identifier types (e.g. to avoid a situation where you try to use `device-attest-01` with a DNS identifier, or `dns-01`/`dns-persist-01` with an IP address identifier).