### PR TITLE
Bump badNonce retries to 5

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ impl Client {
         signer: &impl Signer,
         url: &str,
     ) -> Result<BytesResponse, Error> {
-        let mut retries = 3;
+        let mut retries = 5;
         loop {
             let mut response = self
                 .post_attempt(payload, nonce.clone(), signer, url)


### PR DESCRIPTION
We've seen some test failures in the Pebble tests fail like this:

```
---- authz_reuse stdout ----
Error: Api(Problem { type: Some("urn:ietf:params:acme:error:badNonce"), detail: Some("JWS has an invalid anti-replay nonce: t0u_HaJ7I3vhxYeJFAzvIQ"), status: Some(400), subproblems: [] })
```

Pebble rejects 5% of all valid nonces as invalid by default, and we so far retried 3 times on `badNonce`. However, some of these test run enough POST requests that the chance of encountering 3 `badNonce` errors in a row is still substantial. Since retries here should be effectively free in the real world, feels like it could make sense to bump this?

(Alternatively, we could tune `PEBBLE_WFE_NONCEREJECT` down from 5 to something like 2 or 3.)

Recent failures:

- https://github.com/djc/instant-acme/actions/runs/29748295535 (19 hours ago, in `replacement_order`)
- https://github.com/djc/instant-acme/actions/runs/29744688884/job/88359651969 (20 hours ago, in `authz_reuse`)
- https://github.com/djc/instant-acme/actions/runs/29252809205/job/86825246440 (last week, in `replacement_order`)