### PR TITLE
Optional order validity as per RFC 8555 section 7.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rustls = { version = "0.23", default-features = false, optional = true }
 rustls-pki-types = "1.1.0"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.78"
-time = { version = "0.3", default-features = false, features = ["serde", "parsing"], optional = true }
+time = { version = "0.3", default-features = false, features = ["formatting", "parsing", "serde"], optional = true }
 thiserror = "2.0.3"
 tokio = { version = "1.22", features = ["time"] }
 x509-parser = { version = "0.18", default-features = false, optional = true }

--- a/src/types.rs
+++ b/src/types.rs
@@ -451,6 +451,14 @@ pub struct OrderState {
     /// The profile to be used for the order
     #[serde(default)]
     pub profile: Option<String>,
+    /// The requested value of the notBefore field in the certificate
+    #[cfg(feature = "time")]
+    #[serde(default, with = "time::serde::rfc3339::option")]
+    pub not_before: Option<OffsetDateTime>,
+    /// The requested value of the notAfter field in the certificate
+    #[cfg(feature = "time")]
+    #[serde(default, with = "time::serde::rfc3339::option")]
+    pub not_after: Option<OffsetDateTime>,
 }
 
 /// A wrapper for [`AuthorizationState`] as held in the [`OrderState`]
@@ -496,6 +504,18 @@ pub struct NewOrder<'a> {
     identifiers: &'a [Identifier],
     #[serde(skip_serializing_if = "Option::is_none")]
     profile: Option<&'a str>,
+    #[cfg(feature = "time")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    not_before: Option<OffsetDateTime>,
+    #[cfg(feature = "time")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    not_after: Option<OffsetDateTime>,
 }
 
 impl<'a> NewOrder<'a> {
@@ -507,6 +527,10 @@ impl<'a> NewOrder<'a> {
             identifiers,
             replaces: None,
             profile: None,
+            #[cfg(feature = "time")]
+            not_before: None,
+            #[cfg(feature = "time")]
+            not_after: None,
         }
     }
 
@@ -540,6 +564,28 @@ impl<'a> NewOrder<'a> {
     /// Identifiers to be included in the order
     pub fn identifiers(&self) -> &[Identifier] {
         self.identifiers
+    }
+
+    /// Set the requested value of the notBefore field in the certificate
+    ///
+    /// The ACME server is free to ignore this hint: as noted in
+    /// [RFC 8555, Section 7.4](https://www.rfc-editor.org/rfc/rfc8555#section-7.4), the server is
+    /// not required to implement the `notBefore` and `notAfter` fields, and may reject orders that
+    /// include them. Notably, Let's Encrypt does not support them, while private ACME CAs may offer
+    /// more flexibility over the requested validity.
+    #[cfg(feature = "time")]
+    pub fn not_before(mut self, not_before: OffsetDateTime) -> Self {
+        self.not_before = Some(not_before);
+        self
+    }
+
+    /// Set the requested value of the notAfter field in the certificate
+    ///
+    /// See [`not_before()`][Self::not_before()] for caveats.
+    #[cfg(feature = "time")]
+    pub fn not_after(mut self, not_after: OffsetDateTime) -> Self {
+        self.not_after = Some(not_after);
+        self
     }
 }
 
@@ -1074,6 +1120,8 @@ mod tests {
         BasicConstraints, CertificateParams, DistinguishedName, IsCa, Issuer, KeyIdMethod, KeyPair,
         SerialNumber,
     };
+    #[cfg(feature = "time")]
+    use time::format_description::well_known::Rfc3339;
 
     use super::*;
 
@@ -1107,6 +1155,17 @@ mod tests {
             obj.finalize,
             "https://example.com/acme/order/TOlocE8rfgo/finalize"
         );
+        #[cfg(feature = "time")]
+        {
+            assert_eq!(
+                obj.not_before,
+                Some(OffsetDateTime::parse("2016-01-01T00:00:00Z", &Rfc3339).unwrap())
+            );
+            assert_eq!(
+                obj.not_after,
+                Some(OffsetDateTime::parse("2016-01-08T00:00:00Z", &Rfc3339).unwrap())
+            );
+        }
     }
 
     // https://datatracker.ietf.org/doc/html/rfc8555#section-7.5.1

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -39,8 +39,10 @@ use rustls::server::ParsedCertificate;
 use rustls_pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, UnixTime};
 use serde::{Deserialize, Serialize, Serializer};
 use tempfile::NamedTempFile;
-#[cfg(all(feature = "time", feature = "x509-parser"))]
+#[cfg(feature = "time")]
 use time::OffsetDateTime;
+#[cfg(feature = "time")]
+use time::format_description::well_known::Rfc3339;
 use tokio::net::TcpStream;
 use tokio::time::sleep;
 use tracing::{debug, info, trace};
@@ -284,6 +286,30 @@ async fn order_deactivate() -> Result<(), Box<dyn StdError>> {
 
     // With all authz's deactivated, the order should be status == Invalid
     assert_eq!(order.refresh().await?.status, OrderStatus::Invalid);
+
+    Ok(())
+}
+
+/// Test order with optional validity
+#[tokio::test]
+#[ignore]
+#[cfg(feature = "time")]
+async fn order_validity() -> Result<(), Box<dyn StdError>> {
+    try_tracing_init();
+
+    let env = Environment::new(EnvironmentConfig::default()).await?;
+    let idents = dns_identifiers(["example.com"]);
+    let not_before = OffsetDateTime::parse("3333-01-02T04:00:00Z", &Rfc3339)?;
+    let not_after = OffsetDateTime::parse("4444-01-02T04:00:00Z", &Rfc3339)?;
+    let new_order = &NewOrder::new(&idents)
+        .not_before(not_before)
+        .not_after(not_after);
+    let mut order = env.account.new_order(new_order).await?;
+
+    // on success the requested validity carries over to pebbles order state.
+    let state = order.state();
+    assert_eq!(state.not_before, Some(not_before));
+    assert_eq!(state.not_after, Some(not_after));
 
     Ok(())
 }


### PR DESCRIPTION
Adds support for requesting an optional certificate validity period when creating an ACME order, as defined in [RFC 8555, Section 7.4](https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4).

- Adds `not_before` and `not_after` to new orders and order states.
- Omits these fields when they are not set.
- Adds unit and Pebble integration tests.

My use case is to control the validity of the requested certificate when the default validity added to the cert by the ACME CA is not a good fit.