### PR TITLE
profiles: update directory metadata for draft-02 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ specification.
 * Relatively conservative MSRV policy
 
 [ACME renewal information (ARI)]: https://www.rfc-editor.org/rfc/rfc9773.html
-[profiles]: https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/
+[profiles]: https://datatracker.ietf.org/doc/draft-ietf-acme-profiles/
 
 ## Cargo features
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -315,7 +315,7 @@ impl Account {
             .meta
             .profiles
             .iter()
-            .map(|(name, description)| ProfileMeta { name, description })
+            .map(|(name, url)| ProfileMeta { name, url })
     }
 
     /// Get the account ID

--- a/src/types.rs
+++ b/src/types.rs
@@ -687,12 +687,15 @@ pub(crate) struct Meta {
     pub(crate) profiles: HashMap<String, String>,
 }
 
-/// Profile meta information from the server directory
-#[allow(missing_docs)]
+/// Profile information advertised in the server directory
 #[derive(Clone, Copy, Debug)]
 pub struct ProfileMeta<'a> {
+    /// Short unique identifier for the profile
     pub name: &'a str,
-    pub description: &'a str,
+    /// URL pointing to a human-readable description of the profile
+    ///
+    /// This may be a `data:` URI containing an inline description.
+    pub url: &'a str,
 }
 
 #[derive(Serialize)]

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -253,6 +253,22 @@ async fn profiles() -> Result<(), Box<dyn StdError>> {
 
     // Creat an env/initial account
     let mut env = Environment::new(EnvironmentConfig::default()).await?;
+    assert_eq!(
+        env.account
+            .profiles()
+            .find(|profile| profile.name == "default")
+            .unwrap()
+            .url,
+        "data:text/plain,The%20profile%20you%20know%20and%20love",
+    );
+    assert_eq!(
+        env.account
+            .profiles()
+            .find(|profile| profile.name == "shortlived")
+            .unwrap()
+            .url,
+        "https://example.com/docs/profiles/shortlived",
+    );
     let identifiers = dns_identifiers(["example.com"]);
     let cert = env
         .test::<Http01>(&NewOrder::new(&identifiers).profile("shortlived"))
@@ -991,14 +1007,14 @@ impl Default for PebbleConfig {
                 (
                     "default",
                     Profile {
-                        description: "The profile you know and love",
+                        description: "data:text/plain,The%20profile%20you%20know%20and%20love",
                         validity_period: Duration::from_secs(7776000),
                     },
                 ),
                 (
                     "shortlived",
                     Profile {
-                        description: "A short-lived cert profile, without actual enforcement",
+                        description: "https://example.com/docs/profiles/shortlived",
                         validity_period: Duration::from_secs(518400),
                     },
                 ),


### PR DESCRIPTION
[draft-ietf-acme-profiles-02](https://datatracker.ietf.org/doc/draft-ietf-acme-profiles/02/) was [updated](https://github.com/ietf-wg-acme/draft-acme-profiles/pull/21) relative to `-01` to define each advertised profile value as a URL pointing to a human-readable description instead of allowing either prose or a URL. Rename `ProfileMeta::description` to `ProfileMeta::url` to match.

This might not have been worth the semver break on its own, but since `main` is preparing 0.9.0 it's a good time to tidy this up along with other breaking changes.